### PR TITLE
Add csm-high-priority-service pod priority

### DIFF
--- a/kubernetes/spire/requirements.yaml
+++ b/kubernetes/spire/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: cray-service
-    version: 2.7.0
-    repository: "@cray-internal"
+    version: 2.8.0
+    repository: "@cray-algol60"

--- a/kubernetes/spire/templates/jwks/deployment.yaml
+++ b/kubernetes/spire/templates/jwks/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app.kubernetes.io/name: {{ include "spire.name" . }}-jwks
     spec:
       serviceAccountName: {{ include "spire.name" . }}-jwks
+{{- if .Values.jwks.priorityClassName }}
+      priorityClassName: {{ .Values.jwks.priorityClassName }}
+{{- end }}
       affinity:
           podAntiAffinity:
              preferredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/spire/templates/server/deployment.yaml
+++ b/kubernetes/spire/templates/server/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app.kubernetes.io/name: {{ include "spire.name" . }}-server
     spec:
       serviceAccountName: {{ include "spire.name" . }}-server
+{{- if .Values.server.priorityClassName }}
+      priorityClassName: {{ .Values.server.priorityClassName }}
+{{- end }}
       affinity:
           podAntiAffinity:
              preferredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -19,6 +19,7 @@ server:
   database: spire
   maxOpenDBConns: 20
   registrationPort: 54440
+  priorityClassName: csm-high-priority-service
   tokenService:
     computeEntry: /compute/tenant1
     computeClusterEntry: /compute
@@ -61,6 +62,7 @@ cray-service:
     instanceCount: 3
     postgresVersion: "11"
     volumeSize: 60Gi
+    podPriorityClassName: csm-high-priority-service
     users:
       spire: []
     databases:
@@ -107,6 +109,7 @@ jwks:
   logLevel: INFO
   port: 80
   replicaCount: 3
+  priorityClassName: csm-high-priority-service
 
   image:
     repository: dtr.dev.cray.com/cray/cray-spire-jwks


### PR DESCRIPTION
### Summary and Scope

Add pod priority for spire related pods.

### Issues and Related PRs

* CASMPET-4259

### Testing

* vshasta

```
ncn-m001-deabacef:/home/bklein # kubectl get po -n spire spire-postgres-0 -o yaml | grep -i prior
        f:priorityClassName: {}
  preemptionPolicy: PreemptLowerPriority
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

```
ncn-m001-deabacef:/home/bklein # kubectl get po -n spire spire-server-0 -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

```
ncn-m001-deabacef:/home/bklein # kubectl get po -n spire spire-jwks-848bf4dc94-4gqv2 -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

Was a fresh Install tested? N
Was an Upgrade tested?      Y
Was a Downgrade tested?     N
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Fresh install