### PR TITLE
CASMPET-4887 Fix spire-tokens image repo

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 1.0.0
+version: 1.0.1

--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -49,7 +49,7 @@ server:
     pullPolicy: IfNotPresent
 
   registration:
-    repository: dtr.dev.cray.com/cray/cray-spire-tokens
+    repository: dtr.dev.cray.com/cray/spire-tokens
     tag: 2.0.0
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This fixes an issue where the new build image process creates the image as spire-tokens, not cray-spire-tokens.