### PR TITLE
CASMPET-4783 Update spire tokens for CVE-2021-3711

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 0.8.18
+version: 0.8.19

--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -42,8 +42,8 @@ server:
     pullPolicy: IfNotPresent
 
   registration:
-    repository: dtr.dev.cray.com/cray/cray-spire-tokens
-    tag: 0.4.0
+    repository: dtr.dev.cray.com/cray/spire-tokens
+    tag: 0.4.1
     pullPolicy: IfNotPresent
 
   persistentVolume:


### PR DESCRIPTION
### Summary and Scope
This is a patch to release/shasta-1.4 for an updated spire tokens image.

### Issues and Related PRs

* Resolves CASMCMS-4873

### Testing

Tested on:

* VShasta

Confirmed that the base image was deployed.

### Risks and Mitigations

None.