### PR TITLE
Casmpet 4761

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 0.8.19
+version: 0.8.20

--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -38,7 +38,7 @@ server:
 
   image:
     repository: gcr.io/spiffe-io/spire-server
-    tag: 0.12.0
+    tag: 0.12.0-csm0.9
     pullPolicy: IfNotPresent
 
   registration:


### PR DESCRIPTION
update 0.9 chart to use newer version of CVE free spire-server image