### PR TITLE
CASMPET-4928: Update cray-service to 5.0.0 for 1.1

### DIFF
--- a/kubernetes/spire/requirements.yaml
+++ b/kubernetes/spire/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: cray-service
-    version: 2.8.0
-    repository: "@cray-algol60"
+    version: 5.0.0
+    repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"


### PR DESCRIPTION
### Summary and Scope

The spire chart uses the cray-service subchart. For 1.1 a 5.0.0
version was released to avoid versioning problems. 5.0.0 is the
same as 2.8.0 so there won't be any changes.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? No.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-2928

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? N   If not, Why? Don't think it's necessary for this change.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed the chart and saw that spire-servers and spire-jwks pods restarted back to ready. Then I downgraded.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
