### PR TITLE
CASMPET-4913: Switch to algol60 chart repo

### DIFF
--- a/kubernetes/spire/requirements.yaml
+++ b/kubernetes/spire/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: cray-service
     version: 2.6.0
-    repository: "@cray-internal"
+    repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"


### PR DESCRIPTION
The DST chart repository is going away, so switching to the one in
algol60.