### PR TITLE
CASMPET-4935: Bump cray-spire to 1.0.2 to prep for 1.1 release

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 1.0.1
+version: 1.0.2


### PR DESCRIPTION
This includes the change for:

* CASMPET-4928: Update cray-service to 5.0.0 for 1.1

The last release for 1.1 is 1.0.1, so just bumping the patch
number.