### PR TITLE
CASMPET-4438 Add support for only using load balancer

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 0.8.21
+version: 0.8.22

--- a/kubernetes/spire/templates/ncn/configuration.yaml
+++ b/kubernetes/spire/templates/ncn/configuration.yaml
@@ -10,7 +10,11 @@ data:
     agent {
       data_dir = "/root/spire"
       log_level = "INFO"
+      {{- if .Values.server.lbOnly }}
+      server_address = "{{ .Values.server.lbIP }}"
+      {{- else }}
       server_address = "{{ .Values.server.fqdn }}"
+      {{- end }}
       server_port = "8081"
       socket_path = "/root/spire/agent.sock"
       trust_bundle_path = "/root/spire/conf/bundle.crt"

--- a/kubernetes/spire/templates/server/loadbalancer.yaml
+++ b/kubernetes/spire/templates/server/loadbalancer.yaml
@@ -6,7 +6,11 @@ metadata:
   name: {{ template "spire.name" . }}-lb
 spec:
   loadBalancerIP: {{ .Values.server.lbIP }}
+  {{- if .Values.server.lbOnly }}
+  externalTrafficPolicy: Cluster
+  {{- else }}
   externalTrafficPolicy: Local
+  {{- end }}
   ports:
   - name: spire-server
     port: 8081

--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -10,6 +10,7 @@ trustDomain: shasta
 server:
   replicaCount: 3
   lbIP: "10.92.100.82"
+  lbOnly: false
   fqdn: spire.local
   port: 8081
   logLevel: INFO


### PR DESCRIPTION
### Summary and Scope 

This is needed for spire to function properly on Mercury. It 's disabled by default and won't affect Shasta if this change ends up in CSM 0.9.6

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

### Issues and Related PRs

* Partially Resolves CASMPET-4438

### Testing 

Tested on: 

* bobloblaw

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N   If not, Why?  N 
Was an Upgrade tested?      Y/N   If not, Why? Y
Was a Downgrade tested?     Y/N.  If not, Why?  N
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? Manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? Updated the spire chart on bobloblaw and validated that I could join a master to spire.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

None

 