### PR TITLE
CASMPET-3941 Restrict spire-tokens access

### DIFF
--- a/kubernetes/spire/templates/server/networkpolicy.yaml
+++ b/kubernetes/spire/templates/server/networkpolicy.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: access-spire
-  namespace: spire
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
### Summary and Scope

This sets up a network policy to limit who can request a spire token via the spire-tokens service to BSS and request-ncn-join-tokens.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

### Issues and Related PRs

* Resolves CASMPET-3941


### Testing


Tested on:

* Virtual Shasta

Was a fresh Install tested? Y/N   If not, Why? Y
Was an Upgrade tested?      Y/N   If not, Why? Y
Was a Downgrade tested?     Y/N.  If not, Why? Y

### Risks and Mitigations

Requires:

* Additional testing on bare-metal
