### PR TITLE
CASMCMS-7355: Add a BOS workload

### DIFF
--- a/kubernetes/spire/templates/server/configuration.yaml
+++ b/kubernetes/spire/templates/server/configuration.yaml
@@ -149,6 +149,7 @@ data:
 
     {{- if not .Values.server.tokenService.enableXNameWorkloads }}
 
+    create_if_new compute bos-state-reporter /usr/bin/bos-state-reporter-spire-agent
     create_if_new compute cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
     create_if_new compute ckdump /usr/bin/ckdump-spire-agent 864000
     create_if_new compute ckdump_helper /usr/sbin/ckdump_helper 864000
@@ -160,6 +161,7 @@ data:
     create_if_new compute orca /usr/bin/orca-spire-agent
     create_if_new compute wlm /usr/bin/wlm-spire-agent
 
+    create_if_new ncn bos-state-reporter /usr/bin/bos-state-reporter-spire-agent
     create_if_new ncn cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
     create_if_new ncn cpsmount /usr/bin/cpsmount-spire-agent
     create_if_new ncn cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
@@ -170,6 +172,7 @@ data:
 
     create_if_new storage cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
 
+    create_if_new uan bos-state-reporter /usr/bin/bos-state-reporter-spire-agent
     create_if_new uan cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
     create_if_new uan ckdump /usr/bin/ckdump-spire-agent 864000
     create_if_new uan ckdump_helper /usr/sbin/ckdump_helper 864000

--- a/kubernetes/spire/templates/server/workloads.yaml
+++ b/kubernetes/spire/templates/server/workloads.yaml
@@ -50,6 +50,14 @@ data:
           - type: unix
             value: path:/usr/bin/ckdump-spire-agent
         ttl: 864000
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/bos-state-reporter-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/cfs-state-reporter
         selectors:
           - type: unix
@@ -133,6 +141,14 @@ data:
           - type: unix
             value: path:/usr/bin/ckdump-spire-agent
         ttl: 864000
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/bos-state-reporter-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/cfs-state-reporter
         selectors:
           - type: unix
@@ -234,6 +250,14 @@ data:
           - type: unix
             value: path:/usr/bin/ckdump-spire-agent
         ttl: 864000
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/bos-state-reporter-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/cfs-state-reporter
         selectors:
           - type: unix


### PR DESCRIPTION
BOS will report the boot artifacts the node booted with. It needs spire
authentication to do this. Thus, a BOS workloaded was added to the Spire
ConfigMap.

# Testing
This has been tested on Mug, which has a CSM-1.0 installation. I altered the OPA and Spire policies to let the bos-state-reporter through, and the BOS spire-agent on the compute node was able to get a JWT.