### PR TITLE
CASMPET-5148 Enable xname validation by default

### DIFF
--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -30,7 +30,7 @@ server:
     uanEntry: /uan/tenant1
     uanClusterEntry: /uan
     tokenTTL: 10800
-    enableXNameWorkloads: false
+    enableXNameWorkloads: true
   annotations: {}
 
   init:


### PR DESCRIPTION
## Summary and Scope

This fixes an issue where xname validation is enabled in cray-opa by default, but disabled in spire, breaking cfs-state-reporter. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5148](https://connect.us.cray.com/jira/browse/CASMPET-5148)

## Testing

### Tested on:

  * wasp
### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, this is only a value change and requires additional steps when xname validation is disabled.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

None



