### PR TITLE
CASMPET-3939 Add dns server annotation

### DIFF
--- a/kubernetes/spire/templates/server/service.yaml
+++ b/kubernetes/spire/templates/server/service.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "spire.name" . }}-server
     {{- include "spire.common-labels" . | nindent 4 }}
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.server.fqdn }}
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
## Summary and Scope

This adds the external dns annotation so that the spire URL that NCNs use can be easily customized.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-3939](https://connect.us.cray.com/jira/browse/CASMPET-3939)

## Testing

### Tested on:

  * Wasp

### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? N, we cannot test to see if the annotation works with our current automated testing setup
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

None