### PR TITLE
CASMPET-5142 Update how workloads are created

### DIFF
--- a/kubernetes/spire/templates/server/configuration.yaml
+++ b/kubernetes/spire/templates/server/configuration.yaml
@@ -91,6 +91,35 @@ data:
       /opt/spire/bin/spire-server entry create $@ || echo "Entry creation failed: $@"
     }
 
+
+    create_if_new () {
+      type=$1
+      workload=$2
+      agentPath=$3
+      ttl=$4
+
+      if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
+        if [ "$ttl" ]; then
+          ./bin/spire-server entry create \
+            -parentID spiffe://{{ .Values.trustDomain }}/${type} \
+            -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
+            -selector unix:uid:0 \
+            -selector unix:gid:0 \
+            -selector unix:path:${agentPath} \
+            -ttl ${ttl} || echo "Entry creation failed: $@"
+        else 
+          ./bin/spire-server entry create \
+            -parentID spiffe://{{ .Values.trustDomain }}/${type} \
+            -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
+            -selector unix:uid:0 \
+            -selector unix:gid:0 \
+            -selector unix:path:${agentPath} || echo "Entry creation failed: $@"
+        fi
+      else
+        echo "Entry already exists: $@"
+      fi
+    }
+
     # Wait for the socket to appear
     while [ ! -S /tmp/spire-registration.sock ]; do
       echo "Waiting for registration socket"
@@ -103,215 +132,52 @@ data:
       sleep 3
     done
 
-    /opt/spire/bin/spire-server entry show | grep -q "Found 0" || exit 0
+    if /opt/spire/bin/spire-server entry show | grep -q "Found 0"; then
+      create \
+        -node \
+        -spiffeID spiffe://{{ .Values.trustDomain }}/cluster \
+        -selector k8s_sat:cluster:{{ .Values.trustDomain }} \
 
-    create \
-      -node \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/cluster \
-      -selector k8s_sat:cluster:{{ .Values.trustDomain }} \
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/cluster \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/spire-jwks \
-      -selector k8s:ns:{{ .Release.Namespace }} \
-      -selector k8s:sa:spire-jwks \
-      -selector k8s:pod-label:app.kubernetes.io/name:spire-jwks \
-      -selector k8s:container-name:spire-jwks
+      create \
+        -parentID spiffe://{{ .Values.trustDomain }}/cluster \
+        -spiffeID spiffe://{{ .Values.trustDomain }}/spire-jwks \
+        -selector k8s:ns:{{ .Release.Namespace }} \
+        -selector k8s:sa:spire-jwks \
+        -selector k8s:pod-label:app.kubernetes.io/name:spire-jwks \
+        -selector k8s:container-name:spire-jwks
+    fi
 
     {{- if not .Values.server.tokenService.enableXNameWorkloads }}
 
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/cpsmount_helper \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new compute cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
+    create_if_new compute ckdump /usr/bin/ckdump-spire-agent 864000
+    create_if_new compute ckdump_helper /usr/sbin/ckdump_helper 864000
+    create_if_new compute cpsmount /usr/bin/cpsmount-spire-agent
+    create_if_new compute cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new compute dvs-hmi /usr/bin/dvs-hmi-spire-agent
+    create_if_new compute dvs-map /usr/bin/dvs-map-spire-agent
+    create_if_new compute heartbeat /usr/bin/heartbeat-spire-agent
+    create_if_new compute orca /usr/bin/orca-spire-agent
+    create_if_new compute wlm /usr/bin/wlm-spire-agent
 
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/cpsmount_helper \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new ncn cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
+    create_if_new ncn cpsmount /usr/bin/cpsmount-spire-agent
+    create_if_new ncn cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new ncn dvs-hmi /usr/bin/dvs-hmi-spire-agent
+    create_if_new ncn dvs-map /usr/bin/dvs-map-spire-agent
+    create_if_new ncn heartbeat /usr/bin/heartbeat-spire-agent
+    create_if_new ncn orca /usr/bin/orca-spire-agent
 
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/cpsmount_helper \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new storage cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
 
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/cpsmount \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/cpsmount-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/cpsmount \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/cpsmount-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/cpsmount \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/cpsmount-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/heartbeat \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/heartbeat-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/heartbeat \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/heartbeat-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/heartbeat \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/heartbeat-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/orca \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/orca-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/orca \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/orca-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/orca \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/orca-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/ckdump_helper \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/sbin/ckdump_helper \
-      -ttl 864000
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/ckdump_helper \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/sbin/ckdump_helper \
-      -ttl 864000
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/ckdump \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/ckdump-spire-agent \
-      -ttl 864000
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/ckdump \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/ckdump-spire-agent \
-      -ttl 864000
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/cfs-state-reporter \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/cfs-state-reporter-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/storage \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/storage/workload/cfs-state-reporter \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/cfs-state-reporter-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/cfs-state-reporter \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/cfs-state-reporter-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/cfs-state-reporter \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/cfs-state-reporter-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/dvs-map \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/dvs-map-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/dvs-map \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/dvs-map-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/dvs-map \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/dvs-map-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/ncn \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/ncn/workload/dvs-hmi \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/dvs-hmi-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/dvs-hmi \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/dvs-hmi-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/uan \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/uan/workload/dvs-hmi \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/dvs-hmi-spire-agent
-
-    create \
-      -parentID spiffe://{{ .Values.trustDomain }}/compute \
-      -spiffeID spiffe://{{ .Values.trustDomain }}/compute/workload/wlm \
-      -selector unix:uid:0 \
-      -selector unix:gid:0 \
-      -selector unix:path:/usr/bin/wlm-spire-agent
-
+    create_if_new uan cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
+    create_if_new uan ckdump /usr/bin/ckdump-spire-agent 864000
+    create_if_new uan ckdump_helper /usr/sbin/ckdump_helper 864000
+    create_if_new uan cpsmount /usr/bin/cpsmount-spire-agent
+    create_if_new uan cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new uan dvs-hmi /usr/bin/dvs-hmi-spire-agent
+    create_if_new uan dvs-map /usr/bin/dvs-map-spire-agent
+    create_if_new uan heartbeat /usr/bin/heartbeat-spire-agent
+    create_if_new uan orca /usr/bin/orca-spire-agent
     {{- end }}
     exit 0


### PR DESCRIPTION


## Summary and Scope

This changes how workloads are created so that we can add workloads here
without having to also add them to upgrade scripts. Instead when the
spire-server is restarted it'll go and create any workloads that don't
already exist.

This is only for when xname validation is disabled.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5142](https://connect.us.cray.com/jira/browse/CASMPET-5142)

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Validated that new workloads could be created by adding them to the configuration script and rolling spire-server. Also validated that they were properly created on startup and didn't attempt to recreate any existing entries.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

