### PR TITLE
Bump spire 1.2.0

### DIFF
--- a/kubernetes/spire/CHANGELOG.md
+++ b/kubernetes/spire/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [1.2.0]
+### Changed
+- Added external-dns support (CASMPET-3939)
+- Updated cray-service requirement to 6.2.0 (CASMPET-4699)
+- Added network policy to limit access to spire-tokens service (CASMPET-3941)
+- Updated how workloads are created so that new workloads can be easily added
+  without requiring upgrade scripts (CASMPET-5142)

--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 1.1.0
+version: 1.2.0


### PR DESCRIPTION
This is a version bump to 1.20 for a CSM-1.2 release. This adds the following:
- [CASMPET-3939](https://connect.us.cray.com/jira/browse/CASMPET-3939) Added external-dns support 
- [CASMPET-4699](https://connect.us.cray.com/jira/browse/CASMPET-4699) Updated cray-service requirement to 6.2.0 
- [CASMPET-3941](https://connect.us.cray.com/jira/browse/CASMPET-3941) Added network policy to limit access to spire-tokens service 
- [CASMPET-5142](https://connect.us.cray.com/jira/browse/CASMPET-5142]) Updated how workloads are created so that new workloads can be easily added
  without requiring upgrade scripts 
- [CASMPET-5148](https://connect.us.cray.com/jira/browse/CASMPET-5148) - enable xname validation support by default