### PR TITLE
CASMTRIAGE-2730 Fix network policy

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 1.2.0
+version: 1.2.1

--- a/kubernetes/spire/templates/server/networkpolicy.yaml
+++ b/kubernetes/spire/templates/server/networkpolicy.yaml
@@ -9,23 +9,19 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # BSS Access to request tokens for compute and UANs
     - from:
+      # BSS Access to request tokens for compute and UANs
       - namespaceSelector:
           matchLabels:
             name: services
-      - podSelector:
+        podSelector:
           matchLabels:
             app.kubernetes.io/name: cray-bss
-      ports:
-        - protocol: TCP
-          port: 54440
-    # request-ncn-join-token joins kubernetes NCNs via a daemonset
-    - from:
+      # request-ncn-join-token joins kubernetes NCNs via a daemonset
       - namespaceSelector:
           matchLabels:
             name: spire
-      - podSelector:
+        podSelector:
           matchLabels:
             name: request-ncn-join-token
       ports:


### PR DESCRIPTION
## Summary and Scope

This fixes the network policy so that cray-bss can talk to spire-tokens properly.  The version is being bumped in this because the fix needs to be released today so it's included in the next CSM 1.2 alpha.

## Issues and Related PRs

* Partially Resolves [CASMTRIAGE-2730](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2730)


## Testing


### Tested on:

  * wasp
  * Virtual Shasta

### Test description:

I validated this change by using curl in the cray-bss pod to verify that it could access the spire-token service. I also verified that a different pod, keycloak-postgres-0, could not access it.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N, there are no tests for this chart that are run in Jenkins
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

