### PR TITLE
CASMPET-5178 Run containers as nobody

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 1.2.1
+version: 1.3.0

--- a/kubernetes/spire/templates/agent/deployment.yaml
+++ b/kubernetes/spire/templates/agent/deployment.yaml
@@ -24,7 +24,8 @@ spec:
       serviceAccountName: {{ template "spire.name" . }}-agent
       initContainers:
         - name: init-setperms
-          image: "{{ .Values.agent.init.repository }}:{{ .Values.agent.init.tag }}"
+          image: "{{ .Values.agent.init2.repository }}:{{ .Values.agent.init2.tag }}"
+          imagePullPolicy: {{ .Values.agent.init2.pullPolicy }}
           command:
             - '/bin/sh'
           args:

--- a/kubernetes/spire/templates/agent/deployment.yaml
+++ b/kubernetes/spire/templates/agent/deployment.yaml
@@ -19,11 +19,22 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "spire.name" . }}-agent
     spec:
-      hostPID: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ template "spire.name" . }}-agent
       initContainers:
+        - name: init-setperms
+          image: "{{ .Values.agent.init.repository }}:{{ .Values.agent.init.tag }}"
+          command:
+            - '/bin/sh'
+          args:
+            - '-x'
+            - '-c'
+            - 'chown -R 65534:65534 /run/spire/sockets'
+          volumeMounts:
+            - name: {{ template "spire.name" . }}-socket
+              mountPath: /run/spire/sockets
+              readOnly: false
         - name: init
           # This is a small image with wait-for-it, choose whatever image
           # you prefer that waits for a service to be up. This image is built
@@ -33,6 +44,10 @@ spec:
           args: ["-t", "30", "spire-server:{{ .Values.server.port }}"]
       containers:
         - name: {{ template "spire.name" . }}
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           args: ["-config", "/run/spire/config/spire-agent.conf"]

--- a/kubernetes/spire/templates/agent/psp.yaml
+++ b/kubernetes/spire/templates/agent/psp.yaml
@@ -15,7 +15,6 @@ spec:
       min: 1
     rule: MustRunAs
   hostNetwork: true
-  hostPID: true
   privileged: true
   runAsUser:
     rule: RunAsAny

--- a/kubernetes/spire/templates/jwks/deployment.yaml
+++ b/kubernetes/spire/templates/jwks/deployment.yaml
@@ -54,6 +54,10 @@ spec:
       - name: {{ include "spire.name" . }}-jwks
         image: "{{ .Values.jwks.image.repository }}:{{ .Values.jwks.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.jwks.image.pullPolicy }}
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true 
         args: ["-config", "/run/spire/config/spire-jwks-provider.conf"]
         lifecycle:
           postStart:

--- a/kubernetes/spire/templates/server/deployment.yaml
+++ b/kubernetes/spire/templates/server/deployment.yaml
@@ -39,7 +39,8 @@ spec:
                    topologyKey: kubernetes.io/hostname
       initContainers:
         - name: init-setperms
-          image: "{{ .Values.server.init.repository }}:{{ .Values.server.init.tag }}"
+          image: "{{ .Values.server.init2.repository }}:{{ .Values.server.init2.tag }}"
+          imagePullPolicy: {{ .Values.server.init2.pullPolicy }}
           command:
             - '/bin/sh'
           args:

--- a/kubernetes/spire/templates/server/deployment.yaml
+++ b/kubernetes/spire/templates/server/deployment.yaml
@@ -38,6 +38,24 @@ spec:
                        - {{ include "spire.name" . }}-server
                    topologyKey: kubernetes.io/hostname
       initContainers:
+        - name: init-setperms
+          image: "{{ .Values.server.init.repository }}:{{ .Values.server.init.tag }}"
+          command:
+            - '/bin/sh'
+          args:
+            - '-x'
+            - '-c'
+            - 'chown -R 65534:65534 /run/spire/server /shared-socket /run/spire/data'
+          volumeMounts:
+            - name: spire-server
+              mountPath: /run/spire/server
+              readOnly: false
+            - name: spire-shared-socket
+              mountPath: /shared-socket
+              readOnly: false
+            - name: spire-data
+              mountPath: /run/spire/data
+              readOnly: false
         - name: init
           # This is a small image with wait-for-it, choose whatever image
           # you prefer that waits for a service to be up. This image is built
@@ -63,6 +81,10 @@ spec:
         - name: {{ include "spire.name" . }}-server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true 
           env:
             # This env is used to restart pod when this configuration option changes
             - name: connectionPooler
@@ -109,6 +131,10 @@ spec:
         - name: {{ include "spire.name" . }}-registration-server
           image: "{{ .Values.server.registration.repository }}:{{ .Values.server.registration.tag }}"
           imagePullPolicy: {{ .Values.server.registration.pullPolicy }}
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true 
           env:
             - name: SPIRE_DOMAIN
               value: "{{ .Values.trustDomain }}"

--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -105,6 +105,11 @@ agent:
     tag: "20210322"
     pullPolicy: IfNotPresent
 
+  init2:
+    repository: dtr.dev.cray.com/baseos/alpine
+    tag: 3.11.5
+    pullPolicy: IfNotPresent
+
   image:
     repository: gcr.io/spiffe-io/spire-agent
     tag: 0.12.2


### PR DESCRIPTION
## Summary and Scope

This changes the user and group that runs spire containers from root to 65534 (nobody). It requires an init job to change who owns the hostPaths so that the spire-agent and spire-server can still write to the directory. hostPaths are required due to how spire talks using sockets. There's work being done by the spire team to get rid of this requirement, however it's not currently usable.

The version is being bumped in this chart because it will be released after being merged in so that it can get into the latest CSM-1.2 Alpha.

## Issues and Related PRs

* Resolves [CASMPET-5178](https://connect.us.cray.com/jira/browse/CASMPET-5178)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that the default user in each container was nobody and that services were being run as the nobody user. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

When downgrading, the service runs as root again but the directories are still owned by nobody. Since root has access to everything, this shouldn't cause any issues.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

