### PR TITLE
CASMPET-5187 Disable xname workloads by default

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 1.3.0
+version: 1.4.0

--- a/kubernetes/spire/values.yaml
+++ b/kubernetes/spire/values.yaml
@@ -30,7 +30,7 @@ server:
     uanEntry: /uan/tenant1
     uanClusterEntry: /uan
     tokenTTL: 10800
-    enableXNameWorkloads: true
+    enableXNameWorkloads: false
   annotations: {}
 
   init:


### PR DESCRIPTION
## Summary and Scope

This disabled the xname workloads by default. We won't be enabling them by default until we're sure it will work without a performance hit. The version is being bumped as this will be released as soon as it's merged.

## Issues and Related PRs

* Resolves [CASMPET-5187](https://connect.us.cray.com/jira/browse/CASMINST-5187)

## Testing

The enable/disable was tested when the option was added and a retest to disable the functionality is not needed.


## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

