### PR TITLE
CASMTRIAGE-2791 Fix spire-agent pod

### DIFF
--- a/kubernetes/spire/Chart.yaml
+++ b/kubernetes/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.12.0
 name: spire
 description: A Helm chart for spire
-version: 1.4.0
+version: 1.5.0

--- a/kubernetes/spire/templates/agent/configuration.yaml
+++ b/kubernetes/spire/templates/agent/configuration.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   spire-agent.conf: |-
     agent {
-      data_dir = "/run/spire"
+      data_dir = "/tmp/spire"
       log_level = "{{ .Values.agent.logLevel }}"
       server_address = "spire-server"
       server_port = "{{ .Values.server.port }}"

--- a/kubernetes/spire/templates/agent/deployment.yaml
+++ b/kubernetes/spire/templates/agent/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "spire.name" . }}-agent
     spec:
+      hostPID: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ template "spire.name" . }}-agent

--- a/kubernetes/spire/templates/agent/psp.yaml
+++ b/kubernetes/spire/templates/agent/psp.yaml
@@ -15,6 +15,7 @@ spec:
       min: 1
     rule: MustRunAs
   hostNetwork: true
+  hostPID: true
   privileged: true
   runAsUser:
     rule: RunAsAny


### PR DESCRIPTION


## Summary and Scope

spire-jwks was failing because the spire-agent pod was no longer able to
start properly. This updates the configuration and readds the HostPID
option so that spire-agent functions properly.

The version is being bumped because this change is needed asap.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-2791](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2791)
* 
## Testing


### Tested on:

  * hela
  * Virtual Shasta

### Test description:

Validated spire-jwks returned the proper keys instead of "document not available".

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, Bug Fix for previous version
- Were new tests (or test issues/Jiras) created for this change? N. Tests will be created in the future, but require more of a refactoring to the spire chart.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

