### PR TITLE
Fixes CASMPET-5202: use new cray-service for latest pgbouncer

### DIFF
--- a/charts/spire/CHANGELOG.md
+++ b/charts/spire/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0]
+### Changed
+- Update pgbouncer to master-19 for CVE remediation (CASMPET-5202)
+
 ## [1.2.0]
 ### Changed
 - Added external-dns support (CASMPET-3939)

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: spire
-version: 1.6.0
+version: 2.0.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
   - name: cray-service
-    version: ~7.0.0
+    version: ~8.0.0
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: kburns-hpe


### PR DESCRIPTION
## Summary and Scope

Use new cray-service base chart which includes the latest pgbouncer master-19 image. Increased the 
chart major version from 1.x to 2.0, as the base cray-service chart also contains an increased major
version from 7.x to 8.x.

## Issues and Related PRs

* Resolves [CASMPET-5202]
* Merge with/before/after `https://github.com/Cray-HPE/base-charts/pull/34`

## Testing

### Tested on:

  * `wasp`

### Test description:

Tested the new chart on wasp, and verified that the spire-postgres-pooler pods successfully
pulled the latest pgbouncer image. Pod logs showed no errors after being up for more than
30 minutes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

