### PR TITLE
CASMINST-3916 Fix spire network policy

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.1.0
+version: 2.2.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/server/networkpolicy.yaml
+++ b/charts/spire/templates/server/networkpolicy.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -47,6 +47,13 @@ spec:
         podSelector:
           matchLabels:
             name: request-ncn-join-token
+      # joining storage NCNs uses a spire-server pod to request tokens
+      - namespaceSelector:
+          matchLabels:
+            name: spire
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: spire-server
       ports:
         - protocol: TCP
           port: 54440


### PR DESCRIPTION


## Summary and Scope

The spire-server pods need to be able to talk to each other on port
54440. If they can't then the script that setups spire on storage nodes
will fail 2 out of 3 requests.

## Issues and Related PRs

* Resolves [CASMINST-3916](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3916)

## Testing

### Tested on:

  * surtur

### Test description:

Verified that spire-token requests from the spire-registration-server container always succeeded after the upgrade was pushed and that no side effects occurred from the upgrade.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not needed.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

