### PR TITLE
CASMINST-3917 / CASMINST-3919

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2020-2022] Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/charts/.snyk
+++ b/charts/.snyk
@@ -2,19 +2,14 @@
 version: v1.22.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-CC-K8S-47:
-    - '*':
-        reason: Requires analysis
-        expires: 2022-02-01T00:00:00.000Z
-        created: 2021-12-01T07:01:26.815Z
   SNYK-CC-K8S-16:
     - '*':
         reason: Requires analysis
-        expires: 2022-02-01T00:00:00.000Z
+        expires: 2022-03-01T00:00:00.000Z
         created: 2021-12-01T07:01:38.702Z
   SNYK-CC-K8S-43:
     - '*':
         reason: Requires analysis
-        expires: 2022-02-01T00:00:00.000Z
+        expires: 2022-03-01T00:00:00.000Z
         created: 2021-12-01T07:01:43.788Z
 patch: {}

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.2.0
+version: 2.3.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/jwks/deployment.yaml
+++ b/charts/spire/templates/jwks/deployment.yaml
@@ -1,26 +1,26 @@
-#
-# MIT License
-#
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,6 +30,9 @@ metadata:
     {{- include "spire.common-labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.jwks.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "spire.name" . }}-jwks
@@ -48,6 +51,11 @@ spec:
 {{- end }}
       affinity:
           podAntiAffinity:
+             requiredDuringSchedulingIgnoredDuringExecution:
+               - labelSelector:
+                   matchLabels:
+                     app.kubernetes.io/name: {{ include "spire.name" . }}-jwks
+                 topologyKey: "kubernetes.io/hostname"
              preferredDuringSchedulingIgnoredDuringExecution:
                - weight: 1
                  podAffinityTerm:

--- a/charts/spire/templates/patch-pooler-affinity-hook.yaml
+++ b/charts/spire/templates/patch-pooler-affinity-hook.yaml
@@ -1,0 +1,122 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+{{/*
+This hook updates the spooler deployment with pod antiaffinity. This is here
+because the postgres operator doesn't update the deployment automatically. It
+can be removed next release if we don't support skipping this release when
+upgrading.
+*/}}
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "spire.fullname" . }}-pooler-affinity-hook
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "spire.fullname" . }}-pooler-affinity-hook
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "spire.fullname" . }}-pooler-affinity-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "spire.fullname" . }}-pooler-affinity-hook
+roleRef:
+  kind: Role
+  name: {{ template "spire.fullname" . }}-pooler-affinity-hook
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "spire.fullname" . }}-pooler-affinity-hook
+  labels:
+{{ include "spire.common-labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ template "spire.fullname" . }}-node-exporter-hook
+      labels:
+{{ include "spire.common-labels" . | indent 8 }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ template "spire.fullname" . }}-pooler-affinity-hook
+      restartPolicy: Never
+      containers:
+        - name: post-install-job
+          image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          command:
+            - kubectl
+            - patch
+            - deployment
+            - -n
+            - {{ .Release.Namespace }}
+            - spire-postgres-pooler
+            - -p
+            - |
+              {
+                "spec": {
+                  "strategy": {"rollingUpdate": {"maxSurge": 0}},
+                  "template": {
+                    "spec": {
+                      "affinity": {
+                        "podAntiAffinity": {
+                          "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                              "labelSelector": {
+                                "matchLabels": {
+                                  "application": "db-connection-pooler",
+                                  "cluster-name": "spire-postgres",
+                                  "connection-pooler": "spire-postgres-pooler"
+                                }
+                              },
+                              "topologyKey": "kubernetes.io/hostname"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+          securityContext:
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -187,3 +187,9 @@ ncn:
   pause:
     repository: k8s.gcr.io/pause
     tag: 3.2
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
### Summary and Scope

#### CASMINST-3917: Set pod anti-affinity for spire-jwks

The spire-jwks pods could all be running on the same node, and if
that goes down then spire-jwks is not available and this causes
requests through the API gateway to fail due to the auth check in
OPA to fail.

The proposed fix is to set pod-antiaffinity for spire-jwks so that
the pods will not all wind up on the same node.

#### CASMINST-3919: Add post-upgrade hook to set pooler pod antiaffinity

Upgrades were hitting problems when all of the pooler pods wound
up on the same node. While the postgres operator is enhanced to
set the anti-affinity on the pooler deployment it's not smart
enough to update the deployment if it already exists. This adds
a post-upgrade hook that just updates the deployment with the
same settings that the postgres operator would set if it created
the deployment.

#### Note that this also picks up the latest cray-service chart that fixes cray-postgres-db-backup

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

### Issues and Related PRs

* Resolves CASMINST-3917
* Resolves CASMINST-3919

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

```
# Make sure that postgres-operator is running.

# Make sure the right postgres-operator image is being used.
kubectl get deployment -n services cray-postgres-operator -oyaml | grep image:
 - should be 2.2.0

kubectl get deployment -n spire spire-postgres-pooler -oyaml | less
 - check that affinity is set.
 - check that maxSurge is set to 0.

# Can I do a rollout restart?
kubectl rollout restart deployment -n spire spire-postgres-pooler

# Delete a pod and see it restart:
kubectl delete pod -n spire spire-postgres-pooler-7cc866f568-4rxdg

# Try getting a spire-postgres-pooler pod to run on the same node as another pod:
kubectl get nodes
kubectl taint nodes ncn-w001-d16ce556 key1=value1:NoSchedule

kubectl delete pod -n spire spire-postgres-pooler-7cc866f568-csxvs
# The pod should get stuck in Pending

kubectl taint nodes ncn-w001-d16ce556 key1=value1:NoSchedule-
# The pod should start running.

# Delete the pooler deployment, see if it comes back correctly (might take ~5mins)
kubectl delete deployment -n spire spire-postgres-pooler


kubectl get deployment -n spire spire-jwks -oyaml | less
 - check that antiAffinity is set.
 - check that maxSurge is set to 0.

# Can I do a rollout restart?
kubectl rollout restart deployment -n spire spire-jwks

# Delete a pod and see it restart:
kubectl delete pod -n spire spire-jwks-756cb559d8-h5xfm

# Try getting a spire-postgres-pooler pod to run on the same node as another pod:
kubectl get nodes
kubectl taint nodes ncn-w001-d16ce556 key1=value1:NoSchedule

kubectl delete pod -n spire spire-jwks-756cb559d8-lhh62
# The pod should get stuck in Pending

kubectl taint nodes ncn-w001-d16ce556 key1=value1:NoSchedule-
# The pod should start running.


# I can get a token and use it?
ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -D)
function get_token {
  curl -ks -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET https://shasta.vshasta.io/keycloak/realms/shasta/protocol/openid-connect/token | python -c 'import sys, json; print(json.load(sys.stdin)["access_token"])'
}

curl -k -H "Authorization: Bearer $(get_token)" https://shasta.vshasta.io/apis/capmc/capmc/get_node_rules


kubectl get cronjob -n spire spire-postgresql-db-backup -oyaml | grep image:
 - version should be 0.2.1

kubectl patch cronjob -n spire spire-postgresql-db-backup -p '{"spec":{"schedule":"*/3 * * * *"}}'

kubectl logs -n spire spire-postgresql-db-backup-1644002460-6mq8j
```

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: None
