### PR TITLE
CASMINST-4082: bump spire version to 2.3.1

### DIFF
--- a/charts/spire/CHANGELOG.md
+++ b/charts/spire/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.3.1]
+### Changed
+- Bump spire chart version to pull in changes in cray-service 8.1.2 for CVE remediation (CASMINST-4082)
+
 ## [2.0.0]
 ### Changed
 - Update pgbouncer to master-19 for CVE remediation (CASMPET-5202)

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.3.0
+version: 2.3.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:


### PR DESCRIPTION
## Summary and Scope

Bump spire chart patch version from 2.3.0 to 2.3.1, so that the dependent pgbouncer patch version (8.1.2) can be picked up and rebuilt for the spire chart.

## Issues and Related PRs

* Resolves [CASMINST-4082]

## Testing

### Tested on:

  * `mug`

### Test description:

Tested the new chart on mug, and verified that the spire-postgres-pooler pods successfully pulled the latest pgbouncer image. Pod logs showed no errors after being up for more than 15 minutes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. The pgbouncer version upgrade was a patch version upgrade.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

