### PR TITLE
CASMPET-5082 Update image and cronjob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 .vscode
-kubernetes/spire/charts
 kubeconfig
+charts/*/charts

--- a/charts/spire-intermediate/Chart.yaml
+++ b/charts/spire-intermediate/Chart.yaml
@@ -23,14 +23,14 @@
 #
 apiVersion: v2
 name: spire-intermediate
-version: 0.4.1
+version: 0.5.0
 description: A Helm chart for Kubernetes
 home: https://github.com/Cray-HPE/cray-spire
 maintainers:
   - name: kburns-hpe
-appVersion: 0.3.1
+appVersion: 1.0.0
 annotations:
   artifacthub.io/images: |-
     - name: spire-intermediate
-      image: artifactory.algol60.net/csm-docker/stable/spire-intermediate:0.3.1
+      image: artifactory.algol60.net/csm-docker/stable/spire-intermediate:1.0.0
   artifacthub.io/license: MIT

--- a/charts/spire-intermediate/templates/clusterrole.yaml
+++ b/charts/spire-intermediate/templates/clusterrole.yaml
@@ -31,4 +31,4 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "list"]
+  verbs: ["create", "list", "get", "delete"]

--- a/charts/spire-intermediate/templates/cronjob.yaml
+++ b/charts/spire-intermediate/templates/cronjob.yaml
@@ -1,0 +1,56 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "spire-intermediate.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "spire-intermediate.name" . }}
+    {{- include "spire-intermediate.common-labels" . | nindent 4 }}
+spec:
+  schedule: "0 0 * * 1"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+        {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+          serviceAccountName: {{ include "spire-intermediate.fullname" . }}
+          containers:
+          - name: {{ include "spire-intermediate.fullname" . }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            env:
+              - name: VAULT_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: cray-vault-unseal-keys
+                    key: vault-root
+              - name: PKI_PATH
+                value: "{{ .Values.vaultPKIPath }}"
+              - name: NAMESPACES
+                value: "{{ .Values.namespaces }}"

--- a/charts/spire-intermediate/values.yaml
+++ b/charts/spire-intermediate/values.yaml
@@ -28,11 +28,11 @@ nameOverride: ""
 
 global:
   chart:
-    name: "" # set at deploy time automatically, no need to ever set explicitly
-    version: "" # set at deploy time automatically, no need to ever set explicitly
+    name: ""     # set at deploy time automatically, no need to ever set explicitly
+    version: ""  # set at deploy time automatically, no need to ever set explicitly
 
 image:
-  repository: gcr.io/vsh-burnskp-35682334251678603/cray-hpe/spire-intermediate
+  repository: artifactory.algol60.net/csm-docker/stable/spire-intermediate
   tag: 1.0.0
   pullPolicy: IfNotPresent
 

--- a/charts/spire-intermediate/values.yaml
+++ b/charts/spire-intermediate/values.yaml
@@ -28,12 +28,12 @@ nameOverride: ""
 
 global:
   chart:
-    name: ""     # set at deploy time automatically, no need to ever set explicitly
-    version: ""  # set at deploy time automatically, no need to ever set explicitly
+    name: "" # set at deploy time automatically, no need to ever set explicitly
+    version: "" # set at deploy time automatically, no need to ever set explicitly
 
 image:
-  repository: artifactory.algol60.net/csm-docker/stable/spire-intermediate
-  tag: 0.3.1
+  repository: gcr.io/vsh-burnskp-35682334251678603/cray-hpe/spire-intermediate
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 namespaces:


### PR DESCRIPTION
## Summary and Scope

This adds support for checking to see if the existing spire CA certificate is less than a month old and replace it with a new one if it is. This is done via a cronjob that's run once a week. The existing job is kept so that the spire CA can be created upon first install.

## Issues and Related PRs

* Resolves [CASMPET-5082](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5082) 

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Validated that the certificate was updated properly when the conditions were met. Also validated that the cert was created correctly when it didn't already exist and that it wasn't touched when it wasn't ready to be updated.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

