### PR TITLE
CASMCMS-7987: Resolve name mismatch

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.5.0
+version: 2.6.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/server/configuration.yaml
+++ b/charts/spire/templates/server/configuration.yaml
@@ -172,7 +172,7 @@ data:
 
     {{- if not .Values.server.tokenService.enableXNameWorkloads }}
 
-    create_if_new compute bos-state-reporter /usr/bin/bos-state-reporter-spire-agent
+    create_if_new compute bos-reporter /usr/bin/bos-reporter-spire-agent
     create_if_new compute cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
     create_if_new compute ckdump /usr/bin/ckdump-spire-agent 864000
     create_if_new compute ckdump_helper /usr/sbin/ckdump_helper 864000
@@ -184,7 +184,7 @@ data:
     create_if_new compute orca /usr/bin/orca-spire-agent
     create_if_new compute wlm /usr/bin/wlm-spire-agent
 
-    create_if_new ncn bos-state-reporter /usr/bin/bos-state-reporter-spire-agent
+    create_if_new ncn bos-reporter /usr/bin/bos-reporter-spire-agent
     create_if_new ncn cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
     create_if_new ncn cpsmount /usr/bin/cpsmount-spire-agent
     create_if_new ncn cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
@@ -195,7 +195,7 @@ data:
 
     create_if_new storage cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
 
-    create_if_new uan bos-state-reporter /usr/bin/bos-state-reporter-spire-agent
+    create_if_new uan bos-reporter /usr/bin/bos-reporter-spire-agent
     create_if_new uan cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
     create_if_new uan ckdump /usr/bin/ckdump-spire-agent 864000
     create_if_new uan ckdump_helper /usr/sbin/ckdump_helper 864000

--- a/charts/spire/templates/server/workloads.yaml
+++ b/charts/spire/templates/server/workloads.yaml
@@ -73,14 +73,14 @@ data:
           - type: unix
             value: path:/usr/bin/ckdump-spire-agent
         ttl: 864000
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-state-reporter
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-reporter
         selectors:
           - type: unix
             value: uid:0
           - type: unix
             value: gid:0
           - type: unix
-            value: path:/usr/bin/bos-state-reporter-spire-agent
+            value: path:/usr/bin/bos-reporter-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/cfs-state-reporter
         selectors:
           - type: unix
@@ -164,14 +164,14 @@ data:
           - type: unix
             value: path:/usr/bin/ckdump-spire-agent
         ttl: 864000
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-state-reporter
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-reporter
         selectors:
           - type: unix
             value: uid:0
           - type: unix
             value: gid:0
           - type: unix
-            value: path:/usr/bin/bos-state-reporter-spire-agent
+            value: path:/usr/bin/bos-reporter-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/cfs-state-reporter
         selectors:
           - type: unix
@@ -273,14 +273,14 @@ data:
           - type: unix
             value: path:/usr/bin/ckdump-spire-agent
         ttl: 864000
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-state-reporter
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-reporter
         selectors:
           - type: unix
             value: uid:0
           - type: unix
             value: gid:0
           - type: unix
-            value: path:/usr/bin/bos-state-reporter-spire-agent
+            value: path:/usr/bin/bos-reporter-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/cfs-state-reporter
         selectors:
           - type: unix


### PR DESCRIPTION
## Summary and Scope

The BOS reporter creates a symlink on the compute nodes called
/usr/bin/bos-reporter-spire-agent. The Spire OPA rules uses the name
/usr/bin/bos-state-reporter-spire-agent. These need to match, so I'm
changing the Spire name to be called /usr/bin/bos-reporter-spire-agent.


## Issues and Related PRs
CASMCMS-7987

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Hela


### Test description:
I made the following manual changes on Hela:
I changed the configmaps for  opa-policy-ingressgateway and  spire-workloads to reflect the proper names.
I then restarted cray-opa-ingressgateway deployment and the spire-server stateful sets.
I installed a new RPM on the compute node that had the correct name change as well.
After doing all of this, the BOS client freshly installed on the compute node could communicate with the BOS components API. Previously, it had been unable to due to the name mismatch.

## Risks and Mitigations
Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

