### PR TITLE
CASMINST-4505: use updated images for CVE remediation

### DIFF
--- a/charts/spire/CHANGELOG.md
+++ b/charts/spire/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.5.0]
+### Changed
+- Bump spire chart version to use spire-tokens:2.1.0 for CVE remediation (CASMINST-4505)
+
 ## [2.3.1]
 ### Changed
 - Bump spire chart version to pull in changes in cray-service 8.1.2 for CVE remediation (CASMINST-4082)

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.4.0
+version: 2.5.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
@@ -40,9 +40,9 @@ annotations:
     - name: spire-bundle
       image: artifactory.algol60.net/csm-docker/stable/spire-bundle:0.2.0
     - name: spire-tokens
-      image: artifactory.algol60.net/csm-docker/stable/spire-tokens:2.0.0
+      image: artifactory.algol60.net/csm-docker/stable/spire-tokens:2.1.0
     - name: wait-for-it
-      image: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it:20211201
+      image: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it:1.0.0
     - name: alpine
       image: alpine:3.14
     - name: curl

--- a/charts/spire/templates/agent/deployment.yaml
+++ b/charts/spire/templates/agent/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: init
           # This is a small image with wait-for-it, choose whatever image
           # you prefer that waits for a service to be up. This image is built
-          # from https://github.com/lqhl/wait-for-it
+          # from https://github.com/Cray-HPE/container-images
           image: "{{ .Values.agent.init.repository }}:{{ .Values.agent.init.tag }}"
           imagePullPolicy: {{ .Values.agent.init.pullPolicy }}
           args: ["-t", "30", "spire-server:{{ .Values.server.port }}"]

--- a/charts/spire/templates/server/deployment.yaml
+++ b/charts/spire/templates/server/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: init
           # This is a small image with wait-for-it, choose whatever image
           # you prefer that waits for a service to be up. This image is built
-          # from https://github.com/lqhl/wait-for-it
+          # from https://github.com/Cray-HPE/container-images
           image: "{{ .Values.server.init.repository }}:{{ .Values.server.init.tag }}"
           imagePullPolicy: {{ .Values.server.init.pullPolicy }}
           args: ["-t", "30", "{{ include "spire.fullname" . }}-postgres:5432"]

--- a/charts/spire/tests/kuttl/deployments/02-assert.yaml
+++ b/charts/spire/tests/kuttl/deployments/02-assert.yaml
@@ -140,7 +140,7 @@ spec:
             - -t
             - "30"
             - spire-postgres:5432
-          image: arti.dev.cray.com/third-party-docker-stable-local/sdlc-ops/wait-for-it:20210322
+          image: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it:1.0.0
           imagePullPolicy: IfNotPresent
           name: init
           resources: {}

--- a/charts/spire/tests/kuttl/deployments/04-assert.yaml
+++ b/charts/spire/tests/kuttl/deployments/04-assert.yaml
@@ -77,7 +77,7 @@ spec:
             - -t
             - "30"
             - spire-server:8081
-          image: arti.dev.cray.com/third-party-docker-stable-local/sdlc-ops/wait-for-it:20210322
+          image: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it:1.0.0
           imagePullPolicy: IfNotPresent
           name: init
           resources: {}

--- a/charts/spire/tests/kuttl/values.yaml
+++ b/charts/spire/tests/kuttl/values.yaml
@@ -26,7 +26,8 @@ server:
   disableServiceMonitor: true
   replicaCount: 1
   init:
-    repository: arti.dev.cray.com/third-party-docker-stable-local/sdlc-ops/wait-for-it
+    repository: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it
+    tag: "1.0.0"
 
   init2:
     repository: artifactory.algol60.net/docker.io/alpine
@@ -38,7 +39,8 @@ server:
 
 agent:
   init:
-    repository: arti.dev.cray.com/third-party-docker-stable-local/sdlc-ops/wait-for-it
+    repository: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it
+    tag: "1.0.0"
 
 cray-service:
   sqlCluster:
@@ -59,7 +61,8 @@ cray-service:
 
 
   init:
-    repository: arti.dev.cray.com/third-party-docker-stable-local/sdlc-ops/wait-for-it
+    repository: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it
+    tag: "1.0.0"
 
 jwks:
   replicaCount: 1

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -58,7 +58,7 @@ server:
 
   init:
     repository: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it
-    tag: "20211201"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
 
   init2:
@@ -73,7 +73,7 @@ server:
 
   registration:
     repository: artifactory.algol60.net/csm-docker/stable/spire-tokens
-    tag: 2.0.0
+    tag: 2.1.0
     pullPolicy: IfNotPresent
 
   persistentVolume:
@@ -125,7 +125,7 @@ agent:
 
   init:
     repository: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it
-    tag: "20211201"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
 
   init2:


### PR DESCRIPTION
## Summary and Scope

This PR uses updated images (spire-tokens & wait-for-it) for CVE remediation with automated rebuild.

## Issues and Related PRs

* Resolves [CASMINST-4505](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4505)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Upgraded spire chart; validated that it uses the new images, and ncn-join-tokens are generated correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

