### PR TITLE
CASMINST-4734 Change pod affinity to required

### DIFF
--- a/charts/.snyk
+++ b/charts/.snyk
@@ -5,11 +5,11 @@ ignore:
   SNYK-CC-K8S-16:
     - '*':
         reason: Requires analysis
-        expires: 2022-03-01T00:00:00.000Z
+        expires: 2022-09-01T00:00:00.000Z
         created: 2021-12-01T07:01:38.702Z
   SNYK-CC-K8S-43:
     - '*':
-        reason: Requires analysis
-        expires: 2022-03-01T00:00:00.000Z
+        reason: computes need to talk directly to spire in order to avoid NAT IP issues
+        expires: 2031-01-01T00:00:00.000Z
         created: 2021-12-01T07:01:43.788Z
 patch: {}

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.6.0
+version: 2.6.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/kind.yaml
+++ b/charts/spire/kind.yaml
@@ -24,5 +24,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- role: control-plane
-  image: kindest/v1.19.7@sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
+  - role: control-plane
+    image: kindest/node:v1.20.15@sha256:723256355216daf57d92fb12a209181badb6db635b804372d475d7117d60add2

--- a/charts/spire/templates/bundle/deployment.yaml
+++ b/charts/spire/templates/bundle/deployment.yaml
@@ -47,14 +47,14 @@ spec:
       serviceAccountName: {{ include "spire.name" . }}-bundle
       affinity:
           podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-                - {{ include "spire.name" . }}-bundle
-          topologyKey: kubernetes.io/hostname
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - {{ include "spire.name" . }}-bundle
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ template "spire.name" . }}-bundle
           image: "{{ .Values.bundle.image.repository }}:{{ .Values.bundle.image.tag | default .Chart.AppVersion }}"

--- a/charts/spire/templates/bundle/deployment.yaml
+++ b/charts/spire/templates/bundle/deployment.yaml
@@ -47,16 +47,14 @@ spec:
       serviceAccountName: {{ include "spire.name" . }}-bundle
       affinity:
           podAntiAffinity:
-             preferredDuringSchedulingIgnoredDuringExecution:
-               - weight: 1
-                 podAffinityTerm:
-                   labelSelector:
-                     matchExpressions:
-                     - key: app
-                       operator: In
-                       values:
-                       - {{ include "spire.name" . }}-bundle
-                   topologyKey: kubernetes.io/hostname
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - {{ include "spire.name" . }}-bundle
+          topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ template "spire.name" . }}-bundle
           image: "{{ .Values.bundle.image.repository }}:{{ .Values.bundle.image.tag | default .Chart.AppVersion }}"

--- a/charts/spire/templates/jwks/deployment.yaml
+++ b/charts/spire/templates/jwks/deployment.yaml
@@ -53,19 +53,12 @@ spec:
           podAntiAffinity:
              requiredDuringSchedulingIgnoredDuringExecution:
                - labelSelector:
-                   matchLabels:
-                     app.kubernetes.io/name: {{ include "spire.name" . }}-jwks
-                 topologyKey: "kubernetes.io/hostname"
-             preferredDuringSchedulingIgnoredDuringExecution:
-               - weight: 1
-                 podAffinityTerm:
-                   labelSelector:
-                     matchExpressions:
-                     - key: app
-                       operator: In
-                       values:
-                       - {{ include "spire.name" . }}-server
-                   topologyKey: kubernetes.io/hostname
+                   matchExpressions:
+                   - key: app.kubernetes.io/name
+                     operator: In
+                     values:
+                       - {{ include "spire.name" . }}-jwks
+                 topologyKey: kubernetes.io/hostname
       initContainers:
       - name: init
         # Wait for the agent workload socket to appear
@@ -88,7 +81,7 @@ spec:
         securityContext:
           runAsUser: 65534
           runAsGroup: 65534
-          runAsNonRoot: true 
+          runAsNonRoot: true
         args: ["-config", "/run/spire/config/spire-jwks-provider.conf"]
         lifecycle:
           postStart:

--- a/charts/spire/templates/patch-pooler-affinity-hook.yaml
+++ b/charts/spire/templates/patch-pooler-affinity-hook.yaml
@@ -98,18 +98,22 @@ spec:
                     "spec": {
                       "affinity": {
                         "podAntiAffinity": {
-                          "requiredDuringSchedulingIgnoredDuringExecution": [
-                            {
-                              "labelSelector": {
-                                "matchLabels": {
-                                  "application": "db-connection-pooler",
-                                  "cluster-name": "spire-postgres",
-                                  "connection-pooler": "spire-postgres-pooler"
-                                }
-                              },
-                              "topologyKey": "kubernetes.io/hostname"
-                            }
-                          ]
+                           "requiredDuringSchedulingIgnoredDuringExecution": [
+                              {
+                                  "labelSelector": {
+                                      "matchExpressions": [
+                                          {
+                                              "key": "app.kubernetes.io/name",
+                                              "operator": "In",
+                                              "values": [
+                                                  "spire-jwks"
+                                              ]
+                                          }
+                                      ]
+                                  },
+                                  "topologyKey": "kubernetes.io/hostname"
+                              }
+                            ]
                         }
                       }
                     }

--- a/charts/spire/templates/server/deployment.yaml
+++ b/charts/spire/templates/server/deployment.yaml
@@ -50,16 +50,14 @@ spec:
 {{- end }}
       affinity:
           podAntiAffinity:
-             preferredDuringSchedulingIgnoredDuringExecution:
-               - weight: 1
-                 podAffinityTerm:
-                   labelSelector:
-                     matchExpressions:
-                     - key: app
-                       operator: In
-                       values:
+             requiredDuringSchedulingIgnoredDuringExecution:
+               - labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
                        - {{ include "spire.name" . }}-server
-                   topologyKey: kubernetes.io/hostname
+                 topologyKey: kubernetes.io/hostname
       initContainers:
         - name: init-setperms
           image: "{{ .Values.server.init2.repository }}:{{ .Values.server.init2.tag }}"
@@ -108,7 +106,7 @@ spec:
           securityContext:
             runAsUser: 65534
             runAsGroup: 65534
-            runAsNonRoot: true 
+            runAsNonRoot: true
           env:
             # This env is used to restart pod when this configuration option changes
             - name: connectionPooler
@@ -158,7 +156,7 @@ spec:
           securityContext:
             runAsUser: 65534
             runAsGroup: 65534
-            runAsNonRoot: true 
+            runAsNonRoot: true
           env:
             - name: SPIRE_DOMAIN
               value: "{{ .Values.trustDomain }}"

--- a/charts/spire/tests/kuttl/deployments/02-assert.yaml
+++ b/charts/spire/tests/kuttl/deployments/02-assert.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:

--- a/charts/spire/tests/kuttl/deployments/03-assert.yaml
+++ b/charts/spire/tests/kuttl/deployments/03-assert.yaml
@@ -45,7 +45,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:


### PR DESCRIPTION
## Summary and Scope

Change pod affinity from preferred to required. If these pods all end up scheduled on the same node then when that node goes down so does the API gateway.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4734](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4734)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that the podAffinity policies were changed to requiredDuringSchedulingIgnoredDuringExecution.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

