### PR TITLE
CASMTRIAGE-3616 Revert CASMINST-3979

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.7.0
+version: 2.7.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/jwks/virtualservice.yaml
+++ b/charts/spire/templates/jwks/virtualservice.yaml
@@ -1,0 +1,62 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "spire.name" . }}-jwks
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - services/services-gateway
+  http:
+  - headers:
+      response:
+        set:
+          Cache-Control: max-age=300
+        remove:
+        - expires
+        - pragma
+    match:
+    - method:
+        exact: GET
+      uri:
+        exact: /{{ .Values.jwks.uriPrefix }}/keys
+    rewrite:
+      uri: /keys
+    route:
+    - destination:
+        host: {{ include "spire.name" . }}-jwks
+        port:
+          number: {{ .Values.jwks.port }}
+  - match:
+    - uri:
+        prefix: /{{ .Values.jwks.uriPrefix }}/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: {{ include "spire.name" . }}-jwks
+        port:
+          number: {{ .Values.jwks.port }}

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -140,6 +140,7 @@ agent:
 
 jwks:
   domain: vshasta.io
+  uriPrefix: spire-jwks-vshastaio
   logLevel: INFO
   port: 80
   replicaCount: 3


### PR DESCRIPTION
## Summary and Scope

This reverts the change done in CASMINST-3979. This fixes an issue where the opa pods were failing to properly cache spire-jwks requests, causing port exhaustion which breaks the ingress gateways after a few minutes.

## Issues and Related PRs


* Resolves [CASMTRIAGE-3616](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3616)

## Testing

### Tested on:

  * shandy

### Test description:

validated that connections from opa to spire-jwks no longer ran out of ports.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, downgrade is broken.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This exposes the JWKS public keys. However, these are only useful to validate JWTs and there is no risk associated with this.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

