### PR TITLE
CASMTRIAGE-3714 Fix request-ncn-join-token for CSM 1.3

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -37,6 +37,6 @@ jobs:
       lint-charts: ${{ github.event_name == 'pull_request' }}
       test-charts: false
       scan-chart-snyk-args: "--severity-threshold=high --policy-path=charts/.snyk"
-      #scan-image-snyk-args: "--severity-threshold=high"
+      scan-image-snyk-args: "--policy-path=charts/.snyk"
     secrets:
       snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/charts/.snyk
+++ b/charts/.snyk
@@ -9,7 +9,18 @@ ignore:
         created: 2021-12-01T07:01:38.702Z
   SNYK-CC-K8S-43:
     - '*':
-        reason: computes need to talk directly to spire in order to avoid NAT IP issues
+        reason: >-
+          computes need to talk directly to spire in order to avoid NAT IP
+          issues
         expires: 2031-01-01T00:00:00.000Z
         created: 2021-12-01T07:01:43.788Z
-patch: {}
+  SNYK-ALPINE316-OPENSSL-2941806:
+    - '*':
+        reason: Patched via container-images repo
+        expires: 2022-12-31T15:54:28.130Z
+        created: 2022-07-12T15:54:28.134Z
+  SNYK-ALPINE315-OPENSSL-2941810:
+    - '*':
+        reason: Patched via container-images repo
+        expires: 2022-12-31T15:54:28.130Z
+        created: 2022-07-12T15:54:28.134Z

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.7.1
+version: 2.8.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -44,7 +44,7 @@ annotations:
     - name: wait-for-it
       image: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it:1.0.0
     - name: alpine
-      image: alpine:3.14
+      image: alpine:3.16
     - name: curl
       image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0
     - name: nginx

--- a/charts/spire/templates/ncn/configuration.yaml
+++ b/charts/spire/templates/ncn/configuration.yaml
@@ -31,12 +31,12 @@ metadata:
 data:
   spire-agent.conf: |-
     agent {
-      data_dir = "/root/spire"
+      data_dir = "{{ .Values.ncn.path }}"
       log_level = "INFO"
       server_address = "{{ .Values.server.fqdn }}"
       server_port = "8081"
-      socket_path = "/root/spire/agent.sock"
-      trust_bundle_path = "/root/spire/conf/bundle.crt"
+      socket_path = "{{ .Values.ncn.path }}/agent.sock"
+      trust_bundle_path = "{{ .Values.ncn.path }}/conf/bundle.crt"
       trust_domain = "{{ .Values.trustDomain }}"
       join_token = "$join_token"
     }
@@ -48,7 +48,7 @@ data:
 
       KeyManager "disk" {
         plugin_data {
-            directory = "/root/spire/data"
+            directory = "{{ .Values.ncn.path }}/data"
         }
       }
 

--- a/charts/spire/templates/ncn/deployment.yaml
+++ b/charts/spire/templates/ncn/deployment.yaml
@@ -101,7 +101,7 @@ spec:
       volumes:
         - name: token
           hostPath:
-            path: "{{ .Values.ncn.path }}"
+            path: "{{ .Values.ncn.path }}/conf"
             type: DirectoryOrCreate
         - name: {{ template "spire.name" . }}-config
           configMap:

--- a/charts/spire/templates/ncn/deployment.yaml
+++ b/charts/spire/templates/ncn/deployment.yaml
@@ -63,8 +63,16 @@ spec:
           args:
             - '-x'
             - '-c'
+            {{ if .Values.vshasta }}
+            - 'while ! curl -k -X POST -d "xname=$(echo ${NODE_NAME} | tr -d \-)" "$URL" > /tmp/token; do sleep 5; done; if ! grep -qi error /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}";fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while true; do if test -e /bundle/bundle.crt; then cat /bundle/bundle.crt > /token/bundle.crt; break; fi; sleep 10; done'
+           {{ else }}
             - 'while ! curl -k -X POST -d type=ncn\&xname=$(cat /proc/cmdline | sed "s/.*xname=\([A-Za-z0-9]*\).*/\1/") "$URL" > /tmp/token; do sleep 5; done; if ! grep -qi error /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}";fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while true; do if test -e /bundle/bundle.crt; then cat /bundle/bundle.crt > /token/bundle.crt; break; fi; sleep 10; done'
+           {{ end }}
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: URL
               value: "{{ .Values.ncn.url }}"
           volumeMounts:

--- a/charts/spire/templates/psp/psp.yaml
+++ b/charts/spire/templates/psp/psp.yaml
@@ -32,7 +32,7 @@ spec:
   - NET_RAW
   allowedHostPaths:
   - pathPrefix: /run/spire
-  - pathPrefix: /root/spire/conf
+  - pathPrefix: "{{ .Values.ncn.path }}/conf"
   fsGroup:
     ranges:
     - max: 65535

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -25,8 +25,8 @@ nameOverride: ""
 
 global:
   chart:
-    name: ""     # set at deploy time automatically, no need to ever set explicitly
-    version: ""  # set at deploy time automatically, no need to ever set explicitly
+    name: "" # set at deploy time automatically, no need to ever set explicitly
+    version: "" # set at deploy time automatically, no need to ever set explicitly
 
 trustDomain: shasta
 vshasta: false
@@ -64,7 +64,7 @@ server:
 
   init2:
     repository: alpine
-    tag: 3.14
+    tag: 3.16
     pullPolicy: IfNotPresent
 
   image:
@@ -79,7 +79,7 @@ server:
 
   persistentVolume:
     accessModes:
-    - ReadWriteOnce
+      - ReadWriteOnce
     size: 1Gi
     storageClass: ""
 
@@ -115,7 +115,7 @@ cray-service:
       statement_timeout: "60000"
     backup:
       enabled: true
-      schedule: "10 3 * * *"  # Once per day at 3:10AM
+      schedule: "10 3 * * *" # Once per day at 3:10AM
 
 tls:
   issuer: cert-manager-issuer-common
@@ -131,7 +131,7 @@ agent:
 
   init2:
     repository: alpine
-    tag: 3.14
+    tag: 3.16
     pullPolicy: IfNotPresent
 
   image:
@@ -181,7 +181,7 @@ ncn:
   path: /var/lib/spire
   init:
     repository: alpine
-    tag: 3.14
+    tag: 3.16
   curl:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl
     tag: 7.80.0

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -25,8 +25,8 @@ nameOverride: ""
 
 global:
   chart:
-    name: "" # set at deploy time automatically, no need to ever set explicitly
-    version: "" # set at deploy time automatically, no need to ever set explicitly
+    name: ""     # set at deploy time automatically, no need to ever set explicitly
+    version: ""  # set at deploy time automatically, no need to ever set explicitly
 
 trustDomain: shasta
 vshasta: false
@@ -115,7 +115,7 @@ cray-service:
       statement_timeout: "60000"
     backup:
       enabled: true
-      schedule: "10 3 * * *" # Once per day at 3:10AM
+      schedule: "10 3 * * *"  # Once per day at 3:10AM
 
 tls:
   issuer: cert-manager-issuer-common

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -29,6 +29,7 @@ global:
     version: ""  # set at deploy time automatically, no need to ever set explicitly
 
 trustDomain: shasta
+vshasta: false
 
 server:
   replicaCount: 3

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -178,7 +178,7 @@ bss:
 ncn:
   url: https://spire-tokens.spire:54440/api/token
   filename: join_token
-  path: /root/spire/conf
+  path: /var/lib/spire
   init:
     repository: alpine
     tag: 3.14


### PR DESCRIPTION
## Summary and Scope

This fixes two issues:
- request-ncn-join-token fails to configure spire-agent on CSM 1.3 nodes due to the spire root path changing
- Add a vshasta flag that fixes the issue where request-ncn-join-token failed to request a join_token for vshasta nodes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3714](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3714)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated the paths changed and that setting `vshasta: true` allowed the request-ncn-join-token pod to configure spire-agent on vshasta nodes.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

