### PR TITLE
CASMTRIAGE-3754 Update pause container to 3.4.1

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.8.0
+version: 2.8.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
@@ -50,7 +50,7 @@ annotations:
     - name: nginx
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/nginx:1.18.0-alpine
     - name: pause
-      image: k8s.gcr.io/pause:3.2
+      image: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.4.1
     - name: postgres
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
     - name: postgres-db-backup

--- a/charts/spire/tests/kuttl/deployments/05-assert.yaml
+++ b/charts/spire/tests/kuttl/deployments/05-assert.yaml
@@ -39,7 +39,7 @@ spec:
       name: request-ncn-join-token
     spec:
       containers:
-        - image: k8s.gcr.io/pause:3.2
+        - image: k8s.gcr.io/pause:3.4.1
           imagePullPolicy: IfNotPresent
           name: pause
           resources: {}

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -186,8 +186,8 @@ ncn:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl
     tag: 7.80.0
   pause:
-    repository: k8s.gcr.io/pause
-    tag: 3.2
+    repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause
+    tag: 3.4.1
 
 kubectl:
   image:


### PR DESCRIPTION
## Summary and Scope

Update pause image to 3.4.1. This fixes an issue where the pause container fails to start due to Kyverno modifying its security context to run as nonroot.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3754](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3754)


## Testing

### Tested on:

  * surtur

### Test description:

Validated that the request-ncn-join-token pods came up correctly after the updated spire chart was applied.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not needed.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

