### PR TITLE
CASMPET-5835 Add heartbeat to storage node

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.8.1
+version: 2.9.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/server/configuration.yaml
+++ b/charts/spire/templates/server/configuration.yaml
@@ -130,7 +130,7 @@ data:
             -selector unix:gid:0 \
             -selector unix:path:${agentPath} \
             -ttl ${ttl} || echo "Entry creation failed: $@"
-        else 
+        else
           ./bin/spire-server entry create \
             -parentID spiffe://{{ .Values.trustDomain }}/${type} \
             -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
@@ -194,6 +194,7 @@ data:
     create_if_new ncn orca /usr/bin/orca-spire-agent
 
     create_if_new storage cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
+    create_if_new storage heartbeat /usr/bin/heartbeat-spire-agent
 
     create_if_new uan bos-reporter /usr/bin/bos-reporter-spire-agent
     create_if_new uan cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent

--- a/charts/spire/templates/server/workloads.yaml
+++ b/charts/spire/templates/server/workloads.yaml
@@ -222,6 +222,14 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/storage/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
   uan.yaml: |-
       ---
       - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/cpsmount_helper


### PR DESCRIPTION
## Summary and Scope

heartbeat is now using spire tokens by default. This adds heartbeat workloads for storage nodes.

## Issues and Related PRs


* Resolves [CASMPET-5835](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5835)


## Testing

### Tested on:

  * `fanta`

### Test description:

Validated that storage nodes started heartbeating properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

