### PR TITLE
CASMPET-5873: use new base chart for CVE fix

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,12 +23,12 @@
 #
 apiVersion: v2
 name: spire
-version: 2.9.0
+version: 2.10.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
   - name: cray-service
-    version: ~8.1.0
+    version: ~8.2.0
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: kburns-hpe
@@ -54,7 +54,7 @@ annotations:
     - name: postgres
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
     - name: postgres-db-backup
-      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.2
     - name: spire-server
       image: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-server:0.12.2
     - name: spire-agent


### PR DESCRIPTION
## Summary and Scope

Use the new base chart to include the new postgres-db-backup image for CVE remediation.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5873](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5873)
* Future work required by [CASMPET-5873](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5873)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

Updated the spire chart to use the new base chart, made sure spire used the updated cray-postgres-db-backup image, and its db backup job completed with no errors.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

