### PR TITLE
CASMPET-5966: use cray-postgres-db-backup:0.2.3 image

### DIFF
--- a/charts/spire/CHANGELOG.md
+++ b/charts/spire/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.6.6]
+### Changed
+- Bump spire chart version to use cray-postgres-db-backup:0.2.3 to fix the postgres db restore issue. (CASMPET-5966)
+
 ## [2.5.0]
 ### Changed
 - Bump spire chart version to use spire-tokens:2.1.0 for CVE remediation (CASMINST-4505)

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.6.5
+version: 2.6.6
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
@@ -54,7 +54,7 @@ annotations:
     - name: postgres
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
     - name: postgres-db-backup
-      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
     - name: spire-server
       image: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-server:0.12.2
     - name: spire-agent


### PR DESCRIPTION
## Summary and Scope

Use cray-postgres-db-backup:0.2.3 image to fix postgres db restore issue that was caused by incompatible sql version in previous images.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5966](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5966)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Previously verified that postgres restore issue had been resolved by the updated cray-postgres-db-backup:0.2.3 image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

