### PR TITLE
CASMINST-5650 Add error checking to ncn tokens pod

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.10.1
+version: 2.11.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/ncn/deployment.yaml
+++ b/charts/spire/templates/ncn/deployment.yaml
@@ -21,6 +21,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{- define "getXname" -}}
+{{- if $.Values.vshasta }}
+echo ${NODE_NAME} | tr -d \-
+{{ else }}
+cat /proc/cmdline | sed "s/.*xname=\([A-Za-z0-9]*\).*/\1/"
+{{ end }}
+{{ end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -63,11 +70,7 @@ spec:
           args:
             - '-x'
             - '-c'
-            {{ if .Values.vshasta }}
-            - 'while ! curl -k -X POST -d "xname=$(echo ${NODE_NAME} | tr -d \-)" "$URL" > /tmp/token; do sleep 5; done; if ! grep -qi error /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}";fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while true; do if test -e /bundle/bundle.crt; then cat /bundle/bundle.crt > /token/bundle.crt; break; fi; sleep 10; done'
-           {{ else }}
-            - 'while ! curl -k -X POST -d type=ncn\&xname=$(cat /proc/cmdline | sed "s/.*xname=\([A-Za-z0-9]*\).*/\1/") "$URL" > /tmp/token; do sleep 5; done; if ! grep -qi error /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}";fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while true; do if test -e /bundle/bundle.crt; then cat /bundle/bundle.crt > /token/bundle.crt; break; fi; sleep 10; done'
-           {{ end }}
+            - 'count=0; while [ $count -lt 6 ]; do if ! curl -k -X POST -d type=ncn\&xname=$({{ template "getXname" . }}) "$URL" > /tmp/token; then sleep 5; count=$((count + 1)); else break; fi; done; if [ $count -eq 6 ]; then exit 1; fi; if ! grep -qiE "error|invalid" /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}"; else exit 2;fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while ! [ -e /bundle/bundle.crt ]; do sleep 10; done; cat /bundle/bundle.crt > /token/bundle.crt'
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
## Summary and Scope

This adds error checking to the request-ncn-join-token pods. The pods will now error out if it fails 6 times (30 seconds). This should allow them to restart if the istio-proxy sidecar isn't working.

## Issues and Related PRs

* Resolves [CASMINST-5650](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5650) 

## Testing

### Tested on:

  * mug
  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y 
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

