### PR TITLE
CASMINST-5738: Use local helm config to inherit auth for csm-helm-charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4
 HELM_IMAGE ?= artifactory.algol60.net/docker.io/alpine/helm:3.7.1
 HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/docker.io/quintush/helm-unittest
 HELM_DOCS_IMAGE ?= artifactory.algol60.net/docker.io/jnorwood/helm-docs:v1.5.0
+ifeq ($(shell uname -s),Darwin)
+	HELM_CONFIG_HOME ?= $(HOME)/Library/Preferences/helm
+else
+	HELM_CONFIG_HOME ?= $(HOME)/.config/helm
+endif
+COMMA := ,
 
 all: lint dep-up test package
 
@@ -33,9 +39,10 @@ helm:
 	docker run --rm \
 		--user $(shell id -u):$(shell id -g) \
 		--mount type=bind,src="$(shell pwd)",dst=/src \
+		$(if $(wildcard $(HELM_CONFIG_HOME)/.),--mount type=bind$(COMMA)src=$(HELM_CONFIG_HOME)$(COMMA)dst=/tmp/.helm/config) \
 		-w /src \
 		-e HELM_CACHE_HOME=/src/.helm/cache \
-		-e HELM_CONFIG_HOME=/src/.helm/config \
+		-e HELM_CONFIG_HOME=/tmp/.helm/config \
 		-e HELM_DATA_HOME=/src/.helm/data \
 		$(HELM_IMAGE) \
 		$(CMD)


### PR DESCRIPTION
## Summary and Scope

Fix for artifactory authentication.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5738](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5738)

## Testing

_List the environments in which these changes were tested._

## Testing

Jenkins succeeds and publishes charts

### Tested on:

  * Jenkins

### Test description:

Build pipeline

## Risks and Mitigations

K=Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

