### PR TITLE
CASMPET-5081 Fix alpine image reference

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 3.1.0
+version: 3.1.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
@@ -45,7 +45,7 @@ annotations:
     - name: wait-for-it
       image: artifactory.algol60.net/csm-docker/stable/sdlc-ops/wait-for-it:1.0.0
     - name: alpine
-      image: artifactory.algol60.net/docker.io/alpine:3.16
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.16
     - name: curl
       image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0
     - name: nginx

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -63,7 +63,7 @@ server:
     pullPolicy: IfNotPresent
 
   init2:
-    repository: alpine
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
     tag: 3.16
     pullPolicy: IfNotPresent
 
@@ -130,7 +130,7 @@ agent:
     pullPolicy: IfNotPresent
 
   init2:
-    repository: alpine
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
     tag: 3.16
     pullPolicy: IfNotPresent
 
@@ -180,7 +180,7 @@ ncn:
   filename: join_token
   path: /var/lib/spire
   init:
-    repository: alpine
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
     tag: 3.16
   curl:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl


### PR DESCRIPTION
## Summary and Scope

the reference to alpine no longer validates in the csm repo. The full path needs to be specified.

## Issues and Related PRs

* Partially Resolves [CASMPET-5081](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5081)

## Testing

### Tested on:

  * Local development environment

### Test description:

Used kuttl to validate that chart could be installed with the paths provided.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, not needed
- Was downgrade tested? If not, why? N, not needed
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

