### PR TITLE
CASMPET-6193 Add new spire-agent bin paths

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.10.1
+version: 2.12.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/ncn/deployment.yaml
+++ b/charts/spire/templates/ncn/deployment.yaml
@@ -21,6 +21,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{- define "getXname" -}}
+{{- if $.Values.vshasta }}
+echo ${NODE_NAME} | tr -d \-
+{{ else }}
+cat /proc/cmdline | sed "s/.*xname=\([A-Za-z0-9]*\).*/\1/"
+{{ end }}
+{{ end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -63,11 +70,7 @@ spec:
           args:
             - '-x'
             - '-c'
-            {{ if .Values.vshasta }}
-            - 'while ! curl -k -X POST -d "xname=$(echo ${NODE_NAME} | tr -d \-)" "$URL" > /tmp/token; do sleep 5; done; if ! grep -qi error /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}";fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while true; do if test -e /bundle/bundle.crt; then cat /bundle/bundle.crt > /token/bundle.crt; break; fi; sleep 10; done'
-           {{ else }}
-            - 'while ! curl -k -X POST -d type=ncn\&xname=$(cat /proc/cmdline | sed "s/.*xname=\([A-Za-z0-9]*\).*/\1/") "$URL" > /tmp/token; do sleep 5; done; if ! grep -qi error /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}";fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while true; do if test -e /bundle/bundle.crt; then cat /bundle/bundle.crt > /token/bundle.crt; break; fi; sleep 10; done'
-           {{ end }}
+            - 'count=0; while [ $count -lt 6 ]; do if ! curl -k -X POST -d type=ncn\&xname=$({{ template "getXname" . }}) "$URL" > /tmp/token; then sleep 5; count=$((count + 1)); else break; fi; done; if [ $count -eq 6 ]; then exit 1; fi; if ! grep -qiE "error|invalid" /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}"; else exit 2;fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while ! [ -e /bundle/bundle.crt ]; do sleep 10; done; cat /bundle/bundle.crt > /token/bundle.crt'
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/spire/templates/server/configuration.yaml
+++ b/charts/spire/templates/server/configuration.yaml
@@ -1,26 +1,26 @@
-#
-# MIT License
-#
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
+{{/*
+MIT License
+
+(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -121,8 +121,8 @@ data:
       agentPath=$3
       ttl=$4
 
-      if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
-        if [ "$ttl" ]; then
+      if [ "$ttl" ]; then
+        if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -ttl ${ttl} -selector "unix:path:${agentPath}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
           ./bin/spire-server entry create \
             -parentID spiffe://{{ .Values.trustDomain }}/${type} \
             -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
@@ -131,15 +131,19 @@ data:
             -selector unix:path:${agentPath} \
             -ttl ${ttl} || echo "Entry creation failed: $@"
         else
+          echo "Entry already exists: $@"
+        fi
+      else
+        if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -selector "unix:path:${agentPath}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
           ./bin/spire-server entry create \
             -parentID spiffe://{{ .Values.trustDomain }}/${type} \
             -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
             -selector unix:uid:0 \
             -selector unix:gid:0 \
             -selector unix:path:${agentPath} || echo "Entry creation failed: $@"
+        else
+          echo "Entry already exists: $@"
         fi
-      else
-        echo "Entry already exists: $@"
       fi
     }
 
@@ -206,5 +210,45 @@ data:
     create_if_new uan dvs-map /usr/bin/dvs-map-spire-agent
     create_if_new uan heartbeat /usr/bin/heartbeat-spire-agent
     create_if_new uan orca /usr/bin/orca-spire-agent
+
+    # New Paths
+    create_if_new compute bos-reporter /opt/cray/cray-spire/bos-reporter-spire-agent
+    create_if_new compute cfs-state-reporter /opt/cray/cray-spire/cfs-state-reporter-spire-agent
+    create_if_new compute ckdump /opt/cray/cray-spire/ckdump-spire-agent 864000
+    create_if_new compute ckdump_helper /opt/cray/cray-spire/ckdump_helper 864000
+    create_if_new compute cpsmount /opt/cray/cray-spire/cpsmount-spire-agent
+    create_if_new compute cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new compute dvs-hmi /opt/cray/cray-spire/dvs-hmi-spire-agent
+    create_if_new compute dvs-map /opt/cray/cray-spire/dvs-map-spire-agent
+    create_if_new compute heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
+    create_if_new compute orca /opt/cray/cray-spire/orca-spire-agent
+    create_if_new compute tpm-provisioner /opt/cray/cray-spire/tpm-provisioner
+    create_if_new compute wlm /opt/cray/cray-spire/wlm-spire-agent
+
+    create_if_new ncn bos-reporter /opt/cray/cray-spire/bos-reporter-spire-agent
+    create_if_new ncn cfs-state-reporter /opt/cray/cray-spire/cfs-state-reporter-spire-agent
+    create_if_new ncn cpsmount /opt/cray/cray-spire/cpsmount-spire-agent
+    create_if_new ncn cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new ncn dvs-hmi /opt/cray/cray-spire/dvs-hmi-spire-agent
+    create_if_new ncn dvs-map /opt/cray/cray-spire/dvs-map-spire-agent
+    create_if_new ncn heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
+    create_if_new ncn orca /opt/cray/cray-spire/orca-spire-agent
+    create_if_new ncn tpm-provisioner /opt/cray/cray-spire/tpm-provisioner
+
+    create_if_new storage cfs-state-reporter /opt/cray/cray-spire/cfs-state-reporter-spire-agent
+    create_if_new storage heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
+    create_if_new storage tpm-provisioner /opt/cray/cray-spire/tpm-provisioner
+
+    create_if_new uan bos-reporter /opt/cray/cray-spire/bos-reporter-spire-agent
+    create_if_new uan cfs-state-reporter /opt/cray/cray-spire/cfs-state-reporter-spire-agent
+    create_if_new uan ckdump /opt/cray/cray-spire/ckdump-spire-agent 864000
+    create_if_new uan ckdump_helper /opt/cray/cray-spire/ckdump_helper 864000
+    create_if_new uan cpsmount /opt/cray/cray-spire/cpsmount-spire-agent
+    create_if_new uan cpsmount_helper /opt/cray/cps-utils/bin/cpsmount_helper
+    create_if_new uan dvs-hmi /opt/cray/cray-spire/dvs-hmi-spire-agent
+    create_if_new uan dvs-map /opt/cray/cray-spire/dvs-map-spire-agent
+    create_if_new uan heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
+    create_if_new uan orca /opt/cray/cray-spire/orca-spire-agent
+    create_if_new uan tpm-provisioner /opt/cray/cray-spire/tpm-provisioner
     {{- end }}
     exit 0

--- a/charts/spire/templates/server/workloads.yaml
+++ b/charts/spire/templates/server/workloads.yaml
@@ -113,6 +113,87 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cpsmount-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/orca-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump-spire-agent
+        ttl: 864000
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/bos-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-hmi-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner
   compute.yaml: |-
       ---
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/cpsmount_helper
@@ -212,6 +293,103 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/wlm-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cpsmount-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/orca-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/ckdump_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump_helper
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump-spire-agent
+        ttl: 864000
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/bos-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-hmi-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/wlm
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/wlm-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner
   storage.yaml: |-
       ---
       - spiffeID: spiffe://{{ .Values.trustDomain }}/storage/XNAME/workload/cfs-state-reporter
@@ -230,6 +408,30 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/storage/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/storage/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/storage/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner
   uan.yaml: |-
       ---
       - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/cpsmount_helper
@@ -321,3 +523,92 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cpsmount-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/orca-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/ckdump_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump_helper
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump-spire-agent
+        ttl: 864000
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/bos-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-hmi-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner


### PR DESCRIPTION
## Summary and Scope

This adds new paths to allow the migration of spire-agent binaries from /usr/bin to /opt/cray/cray-spire.

## Issues and Related PRs

* Resolves [CASMPET-6193](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6193)

## Testing

### Tested on:

  * Local development environment

### Test description:

These changes were cherry picked from the master branch.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This needs additional testing on bare metal machines to validate that the changes work with SKERN changes.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

