### PR TITLE
CASMTRIAGE-4857 Fix permission issue with conf dir

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.12.0
+version: 2.12.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/ncn/deployment.yaml
+++ b/charts/spire/templates/ncn/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           args:
             - '-x'
             - '-c'
-            - 'touch /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt; chown 100:101 /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
+            - 'touch /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt; chown 100:101 /token /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
           volumeMounts:
             - name: token
               mountPath: /token
@@ -94,7 +94,7 @@ spec:
           args:
             - '-x'
             - '-c'
-            - 'chown root:root /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
+            - 'chown root:root /token /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
           volumeMounts:
             - name: token
               mountPath: /token


### PR DESCRIPTION
## Summary and Scope

The latest version of the spire-agent RPM locks down the /var/lib/spire/conf directory, breaking the request-ncn-join-token pod. This fixes the issue, allowing NCNs to be joined to spire.


## Issues and Related PRs

* Resolves [CASMTRIAGE-4857](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4857)

## Testing

### Tested on:

  * fanta

### Test description:

validated new chart fixed the issue and that NCNs were properly joined to spire.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

