### PR TITLE
Remove obsolete option for helm unittest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		spire \
 		spire-intermediate
 


### PR DESCRIPTION
The `-3` option in helm unittest has been removed and is breaking the build. This removes the option, allowing it to complete.