### PR TITLE
CASMPET-6421 Bump cray-spire version to 1.5.5

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -46,6 +46,7 @@ pipeline {
             environment {
                 CHART_VERSIONS = [
                     getChartVersion(name: "spire",              chartDirectory: "charts", isStable: env.IS_STABLE),
+                    getChartVersion(name: "cray-spire",         chartDirectory: "charts", isStable: env.IS_STABLE),
                     getChartVersion(name: "spire-intermediate", chartDirectory: "charts", isStable: env.IS_STABLE)
                 ].join(" ")
             }

--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.1.0
+version: 1.1.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
@@ -33,7 +33,7 @@ dependencies:
 maintainers:
   - name: kburns-hpe
   - name: rnoska-hpe
-appVersion: 1.5.4
+appVersion: 1.5.5
 annotations:
   artifacthub.io/images: |-
     - name: cray-spire-jwks
@@ -57,7 +57,7 @@ annotations:
     - name: postgres-db-backup
       image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
     - name: spire-server
-      image: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-server:1.5.4
+      image: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-server:1.5.5
     - name: spire-agent
-      image: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-agent:1.5.4
+      image: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-agent:1.5.5
   artifacthub.io/license: MIT

--- a/charts/cray-spire/values.yaml
+++ b/charts/cray-spire/values.yaml
@@ -69,7 +69,7 @@ server:
 
   image:
     repository: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-server
-    tag: 1.5.4
+    tag: 1.5.5
     pullPolicy: IfNotPresent
 
   registration:
@@ -136,7 +136,7 @@ agent:
 
   image:
     repository: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-agent
-    tag: 1.5.4
+    tag: 1.5.5
     pullPolicy: IfNotPresent
 
 jwks:


### PR DESCRIPTION
## Summary and Scope

This bumps the spire version to 1.5.5 so that it matches the version of spire-agent being deployed in Cheshire Cat.

## Issues and Related PRs

* Resolves [CASMPET-6421](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6421)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, No environment available.
- Was downgrade tested? If not, why? N, No environment available.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

