### PR TITLE
CASMPET-6447 Add backoff and timeout to update-bss job

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.1.2
+version: 1.1.3
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/update-bss/job.yaml
+++ b/charts/cray-spire/templates/update-bss/job.yaml
@@ -28,6 +28,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "spire.name" . }}-update-bss
 spec:
+  backoffLimit: 3
   template:
     metadata:
       labels:
@@ -43,7 +44,7 @@ spec:
             - '-c'
           args:
             - 'retries=1;
-               while ! curl -fv --request PATCH -H "Content-Type: application/json" -d @/conf/bss-update.json "$ENDPOINT";
+               while ! curl --connect-timeout 15 -fv --request PATCH -H "Content-Type: application/json" -d @/conf/bss-update.json "$ENDPOINT";
                  do if [ $retries -gt 9 ];
                    then echo "Failed to add spire entry to BSS";
                    exit 1;


### PR DESCRIPTION
## Summary and Scope

This adds a backoff to the update-bss job and adds a 15 second timer to its curl command. This should allow it to complete properly when run from our csm test pipeline.

## Issues and Related PRs

* Resolves [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing


### Tested on:

  * drax

### Test description:

Generated the job template using helm template and applied it on drax with some minor modifications so it worked with the existing spire install.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, no environment available
- Was downgrade tested? If not, why? N, no environment available
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Limited testing was done due to the lack of an environment to install the full chart. However, due to the small change in this PR the testing should be enough to determine that the job will be applied and run successfully.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

