### PR TITLE
CASMPET-6447 Fix broken integration tests take 3

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.1.3
+version: 1.1.4
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/ncn/deployment.yaml
+++ b/charts/cray-spire/templates/ncn/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           args:
             - '-x'
             - '-c'
-            - 'touch /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt; chown 100:101 /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
+            - 'touch /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt; chown 100:101 /token /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
           volumeMounts:
             - name: token
               mountPath: /token
@@ -94,7 +94,7 @@ spec:
           args:
             - '-x'
             - '-c'
-            - 'chown root:root /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
+            - 'chown root:root /token /token/{{ .Values.ncn.filename }} /token/spire-agent.conf /token/bundle.crt'
           volumeMounts:
             - name: token
               mountPath: /token

--- a/charts/cray-spire/templates/server/networkpolicy.yaml
+++ b/charts/cray-spire/templates/server/networkpolicy.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -43,14 +43,14 @@ spec:
       # request-ncn-join-token joins kubernetes NCNs via a daemonset
       - namespaceSelector:
           matchLabels:
-            name: {{ include "spire.fullname" . }}
+            name: {{ .Release.Namespace }}
         podSelector:
           matchLabels:
             name: request-ncn-join-token
       # joining storage NCNs uses a spire-server pod to request tokens
       - namespaceSelector:
           matchLabels:
-            name: {{ include "spire.fullname" . }}
+            name: {{ .Release.Namespace }}
         podSelector:
           matchLabels:
             app.kubernetes.io/name: {{ include "spire.fullname" . }}-server

--- a/charts/cray-spire/templates/update-bss/job.yaml
+++ b/charts/cray-spire/templates/update-bss/job.yaml
@@ -28,7 +28,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "spire.name" . }}-update-bss
 spec:
-  backoffLimit: 3
+  backoffLimit: 10
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:
@@ -45,7 +46,7 @@ spec:
           args:
             - 'retries=1;
                while ! curl --connect-timeout 15 -fv --request PATCH -H "Content-Type: application/json" -d @/conf/bss-update.json "$ENDPOINT";
-                 do if [ $retries -gt 9 ];
+                 do if [ $retries -gt 20 ];
                    then echo "Failed to add spire entry to BSS";
                    exit 1;
                  fi;


### PR DESCRIPTION
## Summary and Scope

- Fixed incorrect namespace in cray-spire networkpolicy
- Fixed /tokens path permission issues between request-ncn-join-token and spire-agent 1.5.5
- Increased the time spire-update-bss will take to attempt to update BSS and how long it keeps the job pods around.

## Issues and Related PRs

* Resolves [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * yasha
  * Local development environment

### Test description:

Validated Charts changes fixed the issue on yasha

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should fix it.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

