### PR TITLE
CASMPET-6580 Disable postgres backups

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.4.0
+version: 1.4.1
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/values.yaml
+++ b/charts/cray-spire/values.yaml
@@ -113,8 +113,10 @@ cray-postgresql:
       idle_in_transaction_session_timeout: "5000"
       statement_timeout: "60000"
     backup:
-      enableLogicalBackup: true
-      logicalBackupSchedule: "10 3 * * *"  # Once per day at 3:10AM
+      # Backups are disabled due to issues with client SVTs after restores.
+      # It is better to completely reinstall the spire server and rejoin all
+      # nodes than to restore from a backup.
+      enableLogicalBackup: false
 
 tls:
   issuer: cert-manager-issuer-common

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.14.1
+version: 2.14.2
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -112,8 +112,10 @@ cray-postgresql:
       idle_in_transaction_session_timeout: "5000"
       statement_timeout: "60000"
     backup:
-      enableLogicalBackup: true
-      logicalBackupSchedule: "10 3 * * *"  # Once per day at 3:10AM
+      # Backups are disabled due to issues with client SVTs after restores.
+      # It is better to completely reinstall the spire server and rejoin all
+      # nodes than to restore from a backup.
+      enableLogicalBackup: false
 
 tls:
   issuer: cert-manager-issuer-common


### PR DESCRIPTION
Restoring a day old backup will break most of the spire-agents due to restoring outdated authentication information. The proper way to recover is to reinstall the spire helm charts, rejoin NCNs, and restart all UAN and compute nodes.