### PR TITLE
CASMPET-6615 Add new spire paths to PSP

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.4.1
+version: 1.4.2
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/agent/psp.yaml
+++ b/charts/cray-spire/templates/agent/psp.yaml
@@ -31,6 +31,7 @@ spec:
   - NET_ADMIN
   - NET_RAW
   allowedHostPaths:
+  - pathPrefix: /run/cray-spire
   - pathPrefix: /run/spire
   fsGroup:
     ranges:

--- a/charts/cray-spire/templates/psp/psp.yaml
+++ b/charts/cray-spire/templates/psp/psp.yaml
@@ -31,6 +31,7 @@ spec:
   - NET_ADMIN
   - NET_RAW
   allowedHostPaths:
+  - pathPrefix: /run/cray-spire
   - pathPrefix: /run/spire
   - pathPrefix: "{{ .Values.ncn.path }}/conf"
   fsGroup:

--- a/charts/cray-spire/templates/server/deployment.yaml
+++ b/charts/cray-spire/templates/server/deployment.yaml
@@ -210,7 +210,7 @@ spec:
           emptyDir: {}
         - name: shared-socket
           hostPath:
-            path: /run/spire/sockets/shared
+            path: {{ .Values.agent.wlSocket }}/shared
             type: DirectoryOrCreate
         - name: db-creds
           secret:


### PR DESCRIPTION
The hostPath has changed for this chart. However, the PSP was not updated along with this path change, causing the spire-jwks service to fail to start. This fixes the permission issue.