### PR TITLE
CASMPET-6704-master: Update cert-manager api to /v1/ usage

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -28,7 +28,7 @@ description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
   - name: cray-postgresql
-    version: ~1.0.0
+    version: ~1.0
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
   - name: kburns-hpe

--- a/charts/cray-spire/templates/server/certificates.yaml
+++ b/charts/cray-spire/templates/server/certificates.yaml
@@ -23,7 +23,7 @@
 #
 {{- $root := . -}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "spire.fullname" $root }}-tokens-tls"
@@ -33,9 +33,10 @@ spec:
   renewBefore: 24h
   commonName: "{{ include "spire.fullname" $root }}-tokens.{{ .Release.Namespace }}.cluster.svc"
   isCA: false
-  keySize: 4096
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 4096
   usages:
     - server auth
   dnsNames:

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -28,7 +28,7 @@ description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
   - name: cray-postgresql
-    version: ~1.0.0
+    version: ~1.0
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
   - name: kburns-hpe

--- a/charts/spire/templates/server/certificates.yaml
+++ b/charts/spire/templates/server/certificates.yaml
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- $root := . -}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "spire.fullname" $root }}-tokens-tls"
@@ -33,9 +33,10 @@ spec:
   renewBefore: 24h
   commonName: "{{ include "spire.fullname" $root }}-tokens.{{ .Release.Namespace }}.cluster.svc"
   isCA: false
-  keySize: 4096
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 4096
   usages:
     - server auth
   dnsNames:


### PR DESCRIPTION
## Summary and Scope

Since we have a /v1/ compliant cert-manager now, update usage of the certmanager api to /v1/ to be proactive about future updates which will remove all pre /v1/ api's entirely.

## Issues and Related PRs

CASMPET-6704

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

dorian

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta dorian

### Test description:

helm upgrade --installed and validated things still worked

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Not backwards compatible with pre 1.5 certmanager which is too old to support any /v1/ apis.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

