### PR TITLE
CASMTRIAGE-5750 Fix cray-spire TLS failure

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.4.2
+version: 1.5.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/values.yaml
+++ b/charts/cray-spire/values.yaml
@@ -32,7 +32,6 @@ trustDomain: shasta
 vshasta: false
 
 server:
-  disableExternalCerts: true
   replicaCount: 3
   lb:
     local: "10.92.100.83"


### PR DESCRIPTION
disableExternalCerts should only be used during testing and should not be set as a default.
