### PR TITLE
CASMPET-6720 Update cray-service to 8.2.4

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -24,12 +24,12 @@
 ---
 apiVersion: v2
 name: spire
-version: 2.10.3
+version: 2.10.4
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
   - name: cray-service
-    version: ~8.2.0
+    version: ~8.2.4
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: kburns-hpe


### PR DESCRIPTION
This adds the ability to override the default postgresql connection pooler resources.