### PR TITLE
CASMPET-6799: Add SBPS Marshal Spire Workload on NCN

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.5.6
+version: 1.5.7
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/server/configuration.yaml
+++ b/charts/cray-spire/templates/server/configuration.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -202,6 +202,7 @@ data:
     create_if_new ncn dvs-map /usr/bin/dvs-map-spire-agent
     create_if_new ncn heartbeat /usr/bin/heartbeat-spire-agent
     create_if_new ncn orca /usr/bin/orca-spire-agent
+    create_if_new ncn sbps-marshal /usr/bin/sbps-marshal-spire-agent
 
     create_if_new storage cfs-state-reporter /usr/bin/cfs-state-reporter-spire-agent
     create_if_new storage heartbeat /usr/bin/heartbeat-spire-agent
@@ -244,6 +245,7 @@ data:
     create_if_new ncn heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
     create_if_new ncn orca /opt/cray/cray-spire/orca-spire-agent
     create_if_new ncn tpm-provisioner /opt/cray/cray-spire/tpm-provisioner-client
+    create_if_new ncn sbps-marshal /opt/cray/cray-spire/sbps-marshal-spire-agent
 
     create_if_new storage cfs-state-reporter /opt/cray/cray-spire/cfs-state-reporter-spire-agent
     create_if_new storage heartbeat /opt/cray/cray-spire/heartbeat-spire-agent

--- a/charts/cray-spire/templates/server/workloads.yaml
+++ b/charts/cray-spire/templates/server/workloads.yaml
@@ -113,6 +113,14 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/sbps-marshal-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/cpsmount
         selectors:
           - type: unix
@@ -210,6 +218,14 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/tpm-provisioner
+       - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+         selectors:
+           - type: unix
+             value: uid:0
+           - type: unix
+             value: gid:0
+           - type: unix
+             value: path:/opt/cray/cray-spire/sbps-marshal-spire-agent
   compute.yaml: |-
       ---
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/cpsmount_helper

--- a/charts/cray-spire/templates/server/workloads.yaml
+++ b/charts/cray-spire/templates/server/workloads.yaml
@@ -113,7 +113,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/heartbeat-spire-agent
-      - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/workload/sbps-marshal
         selectors:
           - type: unix
             value: uid:0
@@ -218,7 +218,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/tpm-provisioner
-       - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+       - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/workload/sbps-marshal
          selectors:
            - type: unix
              value: uid:0


### PR DESCRIPTION
      sbps-marshal workload needs to be added to spire-server and
      cray-spire-server pods on NCN nodes

## Summary and Scope

sbps-marshal workload which is iSCSI based boot content projection service needs to be added to spire and cray-spire. 

## Testing

Testing is done by adding the entries for sbps-marshal workload into spire and cray-spire manually. Detailed steps are in CASMPET-6799. The same needs to be tested using the CSM latest builds once this code is in.

### Tested on:

  * Mug

### Test description:

Testing is done by adding sbps-marshal workload to spire and cray-spire manually. Detailed steps are listed in the CASMPET-6799.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? - N/A 
- Was upgrade tested? If not, why? - N/A 
- Was downgrade tested? If not, why? - N/A 
- Were new tests (or test issues/Jiras) created for this change? - N/A

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Copyrights updated
- [x] Testing is appropriate and complete, if applicable
