### PR TITLE
CASMTRAIAGE-6550: Add dvs-mqtt-spire-agent workload

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.5.4
+version: 1.5.5
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
@@ -31,8 +31,7 @@ dependencies:
     version: ~1.0.3
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
-  - name: kburns-hpe
-  - name: rnoska-hpe
+  - name: ndavidson-hpe
 appVersion: 1.5.5
 annotations:
   artifacthub.io/images: |-

--- a/charts/cray-spire/templates/server/configuration.yaml
+++ b/charts/cray-spire/templates/server/configuration.yaml
@@ -227,6 +227,7 @@ data:
     create_if_new compute cos-config-helper /opt/cray/cray-spire/cos-config-helper-spire-agent
     create_if_new compute dvs-hmi /opt/cray/cray-spire/dvs-hmi-spire-agent
     create_if_new compute dvs-map /opt/cray/cray-spire/dvs-map-spire-agent
+    create_if_new compute dvs-mqtt /opt/cray/cray-spire/dvs-mqtt-spire-agent
     create_if_new compute heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
     create_if_new compute orca /opt/cray/cray-spire/orca-spire-agent
     create_if_new compute tpm-provisioner /opt/cray/cray-spire/tpm-provisioner-client
@@ -239,6 +240,7 @@ data:
     create_if_new ncn cos-config-helper /opt/cray/cray-spire/cos-config-helper-spire-agent
     create_if_new ncn dvs-hmi /opt/cray/cray-spire/dvs-hmi-spire-agent
     create_if_new ncn dvs-map /opt/cray/cray-spire/dvs-map-spire-agent
+    create_if_new ncn dvs-mqtt /opt/cray/cray-spire/dvs-mqtt-spire-agent
     create_if_new ncn heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
     create_if_new ncn orca /opt/cray/cray-spire/orca-spire-agent
     create_if_new ncn tpm-provisioner /opt/cray/cray-spire/tpm-provisioner-client
@@ -256,6 +258,7 @@ data:
     create_if_new uan cos-config-helper /opt/cray/cray-spire/cos-config-helper-spire-agent
     create_if_new uan dvs-hmi /opt/cray/cray-spire/dvs-hmi-spire-agent
     create_if_new uan dvs-map /opt/cray/cray-spire/dvs-map-spire-agent
+    create_if_new uan dvs-mqtt /opt/cray/cray-spire/dvs-mqtt-spire-agent
     create_if_new uan heartbeat /opt/cray/cray-spire/heartbeat-spire-agent
     create_if_new uan orca /opt/cray/cray-spire/orca-spire-agent
     create_if_new uan tpm-provisioner /opt/cray/cray-spire/tpm-provisioner-client

--- a/charts/cray-spire/templates/server/workloads.yaml
+++ b/charts/cray-spire/templates/server/workloads.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -178,6 +178,14 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/workload/dvs-mqtt
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-mqtt-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/dvs-hmi
         selectors:
           - type: unix
@@ -374,6 +382,14 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/workload/dvs-mqtt
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-mqtt-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/dvs-hmi
         selectors:
           - type: unix
@@ -612,6 +628,14 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/workload/dvs-mqtt
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-mqtt-spire-agent
       - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/dvs-hmi
         selectors:
           - type: unix


### PR DESCRIPTION
## Summary and Scope

Update cray-spire-server to have the dvs-mqtt-spire-agent workloads so that dvs-mqtt can authenticate with spire. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6550](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6550)
* Resolves. [CASMTRIAGE-6551](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6551)

## Testing

### Tested on:

  * Lemondrop
  * odin
 
### Test description:

Manual installation of changes


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No risks adding features that were present in the old spire chart.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

