### PR TITLE
CASMTRIAGE-6625: Update TTL for update-bss job

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.5.5
+version: 1.5.6
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/update-bss/job.yaml
+++ b/charts/cray-spire/templates/update-bss/job.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/name: {{ template "spire.name" . }}-update-bss
 spec:
   backoffLimit: 10
-  ttlSecondsAfterFinished: 86400
+  ttlSecondsAfterFinished: 2629800
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary and Scope
 
Extends the TTL of the update-bss job to 1 month if there are delays on the installation process. This allows for installation to be done over a weekend or week if there are some issues getting through the install in one step.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6625](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6625)

## Testing
### Tested on:

  * mug
  * vidar

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

No risk just extending the TTL on a job.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

