### PR TITLE
CASMPET-6904 update cert-manager apiVersion

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.5.6
+version: 1.6.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/server/certificates.yaml
+++ b/charts/cray-spire/templates/server/certificates.yaml
@@ -23,7 +23,7 @@
 #
 {{- $root := . -}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "spire.fullname" $root }}-tokens-tls"
@@ -33,9 +33,10 @@ spec:
   renewBefore: 24h
   commonName: "{{ include "spire.fullname" $root }}-tokens.{{ .Release.Namespace }}.cluster.svc"
   isCA: false
-  keySize: 4096
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 4096
   usages:
     - server auth
   dnsNames:

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.14.2
+version: 2.15.0
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/server/certificates.yaml
+++ b/charts/spire/templates/server/certificates.yaml
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- $root := . -}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "spire.fullname" $root }}-tokens-tls"
@@ -33,9 +33,10 @@ spec:
   renewBefore: 24h
   commonName: "{{ include "spire.fullname" $root }}-tokens.{{ .Release.Namespace }}.cluster.svc"
   isCA: false
-  keySize: 4096
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 4096
   usages:
     - server auth
   dnsNames:


### PR DESCRIPTION
## Summary and Scope

Update cert-manager api version from v1alpha2 to v1. This is necessary for the cert-manager upgrade to v1.12.9 that is happening in CSM 1.6.

## Issues and Related PRs

* Relates to [CASMPET-6904](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6904)

## Testing

### Tested on:

  * Beau

### Test description:

Upgraded the cray-spire and spire chart.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

