### PR TITLE
CASMPET-7113: Update DVS-mqtt workload definition for Xname validation

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.5.6
+version: 1.5.8
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.5.7
+version: 1.5.6
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/server/workloads.yaml
+++ b/charts/cray-spire/templates/server/workloads.yaml
@@ -178,7 +178,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/workload/dvs-mqtt
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/dvs-mqtt
         selectors:
           - type: unix
             value: uid:0
@@ -382,7 +382,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/workload/dvs-mqtt
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/dvs-mqtt
         selectors:
           - type: unix
             value: uid:0
@@ -628,7 +628,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/workload/dvs-mqtt
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/dvs-mqtt
         selectors:
           - type: unix
             value: uid:0

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.14.3
+version: 2.14.4
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/server/workloads.yaml
+++ b/charts/spire/templates/server/workloads.yaml
@@ -170,7 +170,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/workload/dvs-mqtt
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/XNAME/workload/dvs-mqtt
         selectors:
           - type: unix
             value: uid:0
@@ -366,7 +366,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/workload/dvs-mqtt
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/dvs-mqtt
         selectors:
           - type: unix
             value: uid:0
@@ -604,7 +604,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/dvs-map-spire-agent
-      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/workload/dvs-mqtt
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/dvs-mqtt
         selectors:
           - type: unix
             value: uid:0


### PR DESCRIPTION
## Summary and Scope

Fixes a missed keyword in the workload definition in the new dvs mqtt workload. This lead to spire having two workloads on xname enabled systems one non xname and one with xnames. This lead to the token received first to be the non xname enabled token which failed in the validation on the mqtt broker.

## Issues and Related PRs


* Resolves [CASMPET-7113](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7113)

## Testing

### Tested on:

  *  lemondrop

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

No risks only added needed keyword for xname validation.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

