### PR TITLE
CASMPET-7081 add 'node-role.kubernetes.io/control-plane' toleration for k8s 1.24

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.6.2
+version: 1.6.3
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/ncn/deployment.yaml
+++ b/charts/cray-spire/templates/ncn/deployment.yaml
@@ -51,6 +51,8 @@ spec:
         # this toleration is to have the daemonset runnable on master nodes
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: init-setperms
           image: "{{ .Values.ncn.init.repository }}:{{ .Values.ncn.init.tag }}"

--- a/charts/cray-spire/values.yaml
+++ b/charts/cray-spire/values.yaml
@@ -180,5 +180,5 @@ ncn:
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.15.2
+version: 2.15.3
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/ncn/deployment.yaml
+++ b/charts/spire/templates/ncn/deployment.yaml
@@ -53,6 +53,8 @@ spec:
         # this toleration is to have the daemonset runnable on master nodes
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: init-setperms
           image: "{{ .Values.ncn.init.repository }}:{{ .Values.ncn.init.tag }}"

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -192,5 +192,5 @@ ncn:
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

Update spire and cray-spire charts for k8s 1.24.
These changes include
- adding 'node-role.kubernetes.io/control-plane' toleration
- using container image docker-kubectl:1.24.17

## Issues and Related PRs

* Resolves [CASMPET-7081](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7081)
* Resolves [CASMPET-7082](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7082)

## Testing

Upgraded both charts on Beau. I saw that new toleration was present in 'request-ncn-join-token' pods.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

