### PR TITLE
CASMTRIAGE-7378 Spire server stuck in PodInitializing state forever

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.6.6
+version: 1.6.7
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/server/configuration.yaml
+++ b/charts/cray-spire/templates/server/configuration.yaml
@@ -112,44 +112,22 @@ data:
   register: |-
     #!/bin/sh
 
-    # This is an interim solution until we have a better way for seeding all
-    # the workload and node attestation entries. For now, this allows the
-    # JWKS provider to work and that's it
-
-    create() {
-      /opt/spire/bin/spire-server entry create $@ || echo "Entry creation failed: $@"
-    }
-
-
     create_if_new () {
       type=$1
       workload=$2
       agentPath=$3
       ttl=$4
 
-      if [ "$ttl" ]; then
-        if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -jwtSVIDTTL ${ttl} -selector "unix:path:${agentPath}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
-          ./bin/spire-server entry create \
-            -parentID spiffe://{{ .Values.trustDomain }}/${type} \
-            -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
-            -selector unix:uid:0 \
-            -selector unix:gid:0 \
-            -selector unix:path:${agentPath} \
-            -jwtSVIDTTL ${ttl} || echo "Entry creation failed: $@"
-        else
-          echo "Entry already exists: $@"
-        fi
+      if ! /opt/spire/bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -selector "unix:path:${agentPath}" | grep -q -w "spiffe://shasta/${type}/workload/${workload}"; then
+        /opt/spire/bin/spire-server entry create \
+          -parentID spiffe://{{ .Values.trustDomain }}/${type} \
+          -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
+          -selector unix:uid:0 \
+          -selector unix:gid:0 \
+          -selector unix:path:${agentPath} \
+          ${ttl:+-jwtSVIDTTL ${ttl}} || echo "Entry creation failed: $@"
       else
-        if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -selector "unix:path:${agentPath}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
-          ./bin/spire-server entry create \
-            -parentID spiffe://{{ .Values.trustDomain }}/${type} \
-            -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
-            -selector unix:uid:0 \
-            -selector unix:gid:0 \
-            -selector unix:path:${agentPath} || echo "Entry creation failed: $@"
-        else
-          echo "Entry already exists: $@"
-        fi
+        echo "Entry already exists: $@"
       fi
     }
 
@@ -165,19 +143,22 @@ data:
       sleep 3
     done
 
-    if /opt/spire/bin/spire-server entry show | grep -q "Found 0"; then
-      create \
-        -node \
-        -spiffeID spiffe://{{ .Values.trustDomain }}/cluster \
-        -selector k8s_sat:cluster:{{ .Values.trustDomain }} \
+    spiffe_id="spiffe://{{ .Values.trustDomain }}/cluster"
+    selectors="-selector k8s_sat:cluster:{{ .Values.trustDomain }}"
+    if ! /opt/spire/bin/spire-server entry show -spiffeID "${spiffe_id}" ${selectors} | grep -q -w "${spiffe_id}"; then
+      /opt/spire/bin/spire-server entry create -node -spiffeID "${spiffe_id}" ${selectors}
+    else
+      echo "Entry already exists: ${spiffe_id}"
+    fi
 
-      create \
+    spiffe_id="spiffe://{{ .Values.trustDomain }}/spire-jwks"
+    selectors="-selector k8s:ns:{{ .Release.Namespace }} -selector k8s:sa:{{ include "spire.fullname" . }}-jwks -selector k8s:pod-label:app.kubernetes.io/name:{{ include "spire.fullname" . }}-jwks -selector k8s:container-name:jwks"
+    if ! /opt/spire/bin/spire-server entry show -spiffeID "${spiffe_id}" ${selectors} | grep -q -w "${spiffe_id}"; then
+      /opt/spire/bin/spire-server entry create \
         -parentID spiffe://{{ .Values.trustDomain }}/cluster \
-        -spiffeID spiffe://{{ .Values.trustDomain }}/spire-jwks \
-        -selector k8s:ns:{{ .Release.Namespace }} \
-        -selector k8s:sa:{{ include "spire.fullname" . }}-jwks \
-        -selector k8s:pod-label:app.kubernetes.io/name:{{ include "spire.fullname" . }}-jwks \
-        -selector k8s:container-name:jwks
+        -spiffeID "${spiffe_id}" ${selectors}
+    else
+      echo "Entry already exists: ${spiffe_id}"
     fi
 
     {{- if not .Values.server.tokenService.enableXNameWorkloads }}

--- a/charts/cray-spire/templates/server/deployment.yaml
+++ b/charts/cray-spire/templates/server/deployment.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -122,12 +122,6 @@ spec:
             - name: grpc
               containerPort: {{ .Values.server.port }}
               protocol: TCP
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/bin/sh"
-                  - "/run/spire/config/register"
           livenessProbe:
             tcpSocket:
               port: grpc

--- a/charts/cray-spire/templates/server/registration-hook.yaml
+++ b/charts/cray-spire/templates/server/registration-hook.yaml
@@ -1,0 +1,92 @@
+{{/*
+MIT License
+
+(C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "spire.fullname" . }}-registration-hook
+roleRef:
+  kind: Role
+  name: {{ template "spire.fullname" . }}-registration-hook
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+  labels:
+{{ include "spire.common-labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ template "spire.fullname" . }}-registration-hook
+      labels:
+{{ include "spire.common-labels" . | indent 8 }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ template "spire.fullname" . }}-registration-hook
+      restartPolicy: Never
+      containers:
+        - name: post-install-registration-job
+          image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - kubectl rollout status sts -n {{ .Release.Namespace }} {{ include "spire.fullname" . }}-server &&
+                kubectl exec -n {{ .Release.Namespace }} {{ include "spire.fullname" . }}-server-0 -c spire-server -- /bin/sh /run/spire/config/register
+          securityContext:
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire
-version: 2.15.7
+version: 2.15.8
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/spire/templates/server/configuration.yaml
+++ b/charts/spire/templates/server/configuration.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -108,44 +108,22 @@ data:
   register: |-
     #!/bin/sh
 
-    # This is an interim solution until we have a better way for seeding all
-    # the workload and node attestation entries. For now, this allows the
-    # JWKS provider to work and that's it
-
-    create() {
-      /opt/spire/bin/spire-server entry create $@ || echo "Entry creation failed: $@"
-    }
-
-
     create_if_new () {
       type=$1
       workload=$2
       agentPath=$3
       ttl=$4
 
-      if [ "$ttl" ]; then
-        if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -ttl ${ttl} -selector "unix:path:${agentPath}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
-          ./bin/spire-server entry create \
-            -parentID spiffe://{{ .Values.trustDomain }}/${type} \
-            -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
-            -selector unix:uid:0 \
-            -selector unix:gid:0 \
-            -selector unix:path:${agentPath} \
-            -ttl ${ttl} || echo "Entry creation failed: $@"
-        else
-          echo "Entry already exists: $@"
-        fi
+      if ! /opt/spire/bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -selector "unix:path:${agentPath}" | grep -q -w "spiffe://shasta/${type}/workload/${workload}"; then
+        /opt/spire/bin/spire-server entry create \
+          -parentID spiffe://{{ .Values.trustDomain }}/${type} \
+          -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
+          -selector unix:uid:0 \
+          -selector unix:gid:0 \
+          -selector unix:path:${agentPath} \
+          ${ttl:+-ttl ${ttl}} || echo "Entry creation failed: $@"
       else
-        if ! ./bin/spire-server entry show -spiffeID "spiffe://shasta/${type}/workload/${workload}" -selector "unix:path:${agentPath}" | grep -q "spiffe://shasta/${type}/workload/${workload}"; then
-          ./bin/spire-server entry create \
-            -parentID spiffe://{{ .Values.trustDomain }}/${type} \
-            -spiffeID spiffe://{{ .Values.trustDomain }}/${type}/workload/${workload} \
-            -selector unix:uid:0 \
-            -selector unix:gid:0 \
-            -selector unix:path:${agentPath} || echo "Entry creation failed: $@"
-        else
-          echo "Entry already exists: $@"
-        fi
+        echo "Entry already exists: $@"
       fi
     }
 
@@ -161,19 +139,22 @@ data:
       sleep 3
     done
 
-    if /opt/spire/bin/spire-server entry show | grep -q "Found 0"; then
-      create \
-        -node \
-        -spiffeID spiffe://{{ .Values.trustDomain }}/cluster \
-        -selector k8s_sat:cluster:{{ .Values.trustDomain }} \
+    spiffe_id="spiffe://{{ .Values.trustDomain }}/cluster"
+    selectors="-selector k8s_sat:cluster:{{ .Values.trustDomain }}"
+    if ! /opt/spire/bin/spire-server entry show -spiffeID "${spiffe_id}" ${selectors} | grep -q -w "${spiffe_id}"; then
+      /opt/spire/bin/spire-server entry create -node -spiffeID "${spiffe_id}" ${selectors}
+    else
+      echo "Entry already exists: ${spiffe_id}"
+    fi
 
-      create \
+    spiffe_id="spiffe://{{ .Values.trustDomain }}/spire-jwks"
+    selectors="-selector k8s:ns:{{ .Release.Namespace }} -selector k8s:sa:{{ include "spire.fullname" . }}-jwks -selector k8s:pod-label:app.kubernetes.io/name:{{ include "spire.fullname" . }}-jwks -selector k8s:container-name:jwks"
+    if ! /opt/spire/bin/spire-server entry show -spiffeID "${spiffe_id}" ${selectors} | grep -q -w "${spiffe_id}"; then
+      /opt/spire/bin/spire-server entry create \
         -parentID spiffe://{{ .Values.trustDomain }}/cluster \
-        -spiffeID spiffe://{{ .Values.trustDomain }}/spire-jwks \
-        -selector k8s:ns:{{ .Release.Namespace }} \
-        -selector k8s:sa:spire-jwks \
-        -selector k8s:pod-label:app.kubernetes.io/name:spire-jwks \
-        -selector k8s:container-name:spire-jwks
+        -spiffeID "${spiffe_id}" ${selectors}
+    else
+      echo "Entry already exists: ${spiffe_id}"
     fi
 
     {{- if not .Values.server.tokenService.enableXNameWorkloads }}

--- a/charts/spire/templates/server/deployment.yaml
+++ b/charts/spire/templates/server/deployment.yaml
@@ -122,12 +122,6 @@ spec:
             - name: grpc
               containerPort: {{ .Values.server.port }}
               protocol: TCP
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/bin/sh"
-                  - "/run/spire/config/register"
           livenessProbe:
             tcpSocket:
               port: grpc

--- a/charts/spire/templates/server/registration-hook.yaml
+++ b/charts/spire/templates/server/registration-hook.yaml
@@ -1,0 +1,92 @@
+{{/*
+MIT License
+
+(C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "spire.fullname" . }}-registration-hook
+roleRef:
+  kind: Role
+  name: {{ template "spire.fullname" . }}-registration-hook
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "spire.fullname" . }}-registration-hook
+  labels:
+{{ include "spire.common-labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ template "spire.fullname" . }}-registration-hook
+      labels:
+{{ include "spire.common-labels" . | indent 8 }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: {{ template "spire.fullname" . }}-registration-hook
+      restartPolicy: Never
+      containers:
+        - name: post-install-registration-job
+          image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - kubectl rollout status sts -n {{ .Release.Namespace }} {{ include "spire.fullname" . }}-server &&
+                kubectl exec -n {{ .Release.Namespace }} {{ include "spire.fullname" . }}-server-0 -c spire-server -- /bin/sh /run/spire/config/register
+          securityContext:
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534


### PR DESCRIPTION
## Summary and Scope

Currently, component registration script is run as pod lifecycle post-start hook. This delivers a set of problems:
* For many times, we observe 1st spire server pod in StatefulSet stuck forever in state `PodInitializing`. The remaining pods are not starting waiting for the 1st pod. If attempted to delete/re-create, pod stucks in state `Terminating` forever. The only workaround is to restart `containerd` on a node where pod got stuck, which is not always safe.
* Logs from lifecycle hook are not available to read. In fact, there were some other issues with registration script which proper logging could reveal.
* Lifecycle hook is executed too many times - registration is a one time per cluster per deployment. Livecycle hook executes it for every pod and for every pod restart, which is unnecessary.

This change moves registration script call from lifecycle hook into Helm post-install/post-upgrade hook. This ensures script is executed once per deployment, and provides clear approach to read logs. While testing, also found and fixed unreliable condition check, which may have resulted in sporadic issue CASMPET-7103.

## Issues and Related PRs

* Resolves CASMTRIAGE-7378
* Potentially resolves CASMPET-7103 - need to perform sufficient number of deployments to ensure sporadic bug is not reproduced.

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Created temporary CSM build with updated `spire` and `cray-spire` chart, performed deployment onto vShasta. All spire pods started successfully, also there are 2 new pods named per naming convention:

    pit:~ # kubectl -n spire get pod | grep registration-hook
    cray-spire-registration-hook-z7qqq            0/1     Completed   0          3h29m
    spire-registration-hook-25thp                 0/1     Completed   0          3h32m

Registration hook pod logs provide clear indication that components were properly registered:

    pit:~ # kubectl -n spire logs cray-spire-registration-hook-z7qqq
    Waiting for 3 pods to be ready...
    Waiting for 2 pods to be ready...
    Waiting for 1 pods to be ready...
    partitioned roll out complete: 3 new pods have been updated...
    Server is healthy.
    Entry ID         : 2cd8986b-2bc6-4091-b02e-f42aacf3f1bf
    SPIFFE ID        : spiffe://shasta/cluster
    Parent ID        : spiffe://shasta/spire/server
    Revision         : 0
    X509-SVID TTL    : default
    JWT-SVID TTL     : default
    Selector         : k8s_sat:cluster:shasta
    
    Entry ID         : 95227ebb-cf7d-422d-8e7a-c17d48ebd654
    SPIFFE ID        : spiffe://shasta/spire-jwks
    Parent ID        : spiffe://shasta/cluster
    Revision         : 0
    X509-SVID TTL    : default
    JWT-SVID TTL     : default
    Selector         : k8s:ns:spire
    Selector         : k8s:sa:cray-spire-jwks
    Selector         : k8s:pod-label:app.kubernetes.io/name:cray-spire-jwks
    Selector         : k8s:container-name:jwks
    ...

Additionally, verified that all goss tests, including `spire_check_key_id_in_jwks` are passing. This test does not pass when registration script fails to create entry for  `spiffe://shasta/spire-jwks`.

## Risks and Mitigations

None known.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

