### PR TITLE
CASMPET-7373: Use apiVersion 'batch/v1' in spire-intermediate cronjob.yaml template

### DIFF
--- a/charts/spire-intermediate/Chart.yaml
+++ b/charts/spire-intermediate/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022, 2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: spire-intermediate
-version: 0.5.0
+version: 0.5.1
 description: A Helm chart for Kubernetes
 home: https://github.com/Cray-HPE/cray-spire
 maintainers:

--- a/charts/spire-intermediate/templates/cronjob.yaml
+++ b/charts/spire-intermediate/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022, 2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "spire-intermediate.fullname" . }}


### PR DESCRIPTION

## Summary and Scope
CronJob apiVersion `batch/v1` has been around since k8s 1.21. CronJob apiVersion `batch/v1beta1` is deprecated in K8s 1.25+. Use `batch/v1` in prep for K8s upgrade to 1.32.

## Issues and Related PRs

* Resolves [CASMPET-7373](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7373)

## Testing
Installed chart with changes on `molly` successfully.
```
pit:~/studenym/spire-intermediate # helm install -n vault spire-intermediate .
NAME: spire-intermediate
LAST DEPLOYED: Thu Feb  6 19:44:58 2025
NAMESPACE: vault
STATUS: deployed
REVISION: 1
TEST SUITE: None
pit:~/studenym/spire-intermediate # kubectl get cronjob -n vault
NAME                 SCHEDULE    TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
spire-intermediate   0 0 * * 1   <none>     False     0        <none>          8s
tpm-intermediate     0 0 * * 1   <none>     False     0        <none>          16h
pit:~/studenym/spire-intermediate # helm list -n vault
NAME               	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                    	APP VERSION
cray-vault         	vault    	1       	2025-02-06 02:43:07.316320196 +0000 UTC	deployed	cray-vault-1.7.1         	1.10.8
cray-vault-operator	vault    	1       	2025-02-06 02:42:54.542340196 +0000 UTC	deployed	cray-vault-operator-1.4.0	1.16.0
spire-intermediate 	vault    	1       	2025-02-06 19:44:58.414875316 +0000 UTC	deployed	spire-intermediate-0.5.1 	1.0.0
tpm-intermediate   	vault    	1       	2025-02-06 02:45:37.852057176 +0000 UTC	deployed	tpm-intermediate-1.0.0   	1.0.0
pit:~/studenym/spire-intermediate #
```


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

