### PR TITLE
CASMTRIAGE-7880: Fix indentation issue in workloads.yaml

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.7.1
+version: 1.7.2
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/server/workloads.yaml
+++ b/charts/cray-spire/templates/server/workloads.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -218,14 +218,14 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/tpm-provisioner
-       - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/workload/sbps-marshal
-         selectors:
-           - type: unix
-             value: uid:0
-           - type: unix
-             value: gid:0
-           - type: unix
-             value: path:/opt/cray/cray-spire/sbps-marshal-spire-agent
+      - spiffeID: spiffe://{{ .Values.trustDomain }}/ncn/workload/sbps-marshal
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/sbps-marshal-spire-agent
   compute.yaml: |-
       ---
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/cpsmount_helper


### PR DESCRIPTION
## Summary and Scope

This fixes a bug in the indentation of a workload in workloads.yaml. This bug prevented systems with xname validation enabled from getting tokens for workloads

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-7880](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7880)

## Testing

### Tested on:

  * lemondrop

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

no risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

