### PR TITLE
CASMTRIAGE-7898: fix jwks service account

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.7.3
+version: 1.7.4
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/jwks/deployment.yaml
+++ b/charts/cray-spire/templates/jwks/deployment.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -47,6 +47,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "spire.name" . }}-jwks
     spec:
+      serviceAccountName: {{ include "spire.fullname" . }}-jwks
 {{- if .Values.jwks.priorityClassName }}
       priorityClassName: {{ .Values.jwks.priorityClassName }}
 {{- end }}

--- a/charts/cray-spire/templates/jwks/serviceaccount.yaml
+++ b/charts/cray-spire/templates/jwks/serviceaccount.yaml
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spire.fullname" . }}-jwks
+  labels:
+    app.kubernetes.io/name: {{ template "spire.fullname" . }}-jwks
+    {{- include "spire.common-labels" . | nindent 4 }}


### PR DESCRIPTION
## Summary and Scope

Re-add the spire jwks service account. This fixes a bug where the spire server is unable to properly target jwks pods, because the server config is using the following selector: `k8s:sa:{{ include "spire.fullname" . }}-jwks`.

Whereas currently, the jwks pods are using the default service account, which breaks the `Validate token key ID exists in cray-spire jwks` goss test (and presumably a bunch of other things, too).

We decided to use a dedicated service account, instead of updating the spire server config, to avoid potential unexpected RBAC scope increases on the default service account.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7898](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7898)
* Change will also be needed in CSM, `release/1.7`.

## Testing

### Tested on:

  * `molly`
  * `wasp`

### Test description:

I manually upgraded `cray-spire` to this version on Molly and Wasp and verified that the `cray-spire-jwks` endpoint is successfully returning keys: `kubectl exec -itn spire cray-spire-postgres-0 -c postgres -- curl http://cray-spire-jwks/keys`.

The `cray-spire-jwks` pods are no longer logging any errors as well:

```
time="2025-03-01T23:47:48Z" level=info msg="Logging all requests"
time="2025-03-01T23:47:48Z" level=info msg="Serving HTTP" address=/run/spire/jwks/provider.sock network=unix
```

After restarting the agent pods, the following errors have resolved as well:

```
time="2025-03-01T23:46:23Z" level=error msg="No identity issued" method=FetchJWTBundles pid=3219589 registered=false service=WorkloadAPI subsystem_name=endpoints
time="2025-03-01T23:46:33Z" level=error msg="No identity issued" method=FetchJWTBundles pid=3219589 registered=false service=WorkloadAPI subsystem_name=endpoints
time="2025-03-01T23:46:44Z" level=error msg="No identity issued" method=FetchJWTBundles pid=3219589 registered=false service=WorkloadAPI subsystem_name=endpoints
time="2025-03-01T23:46:54Z" level=error msg="No identity issued" method=FetchJWTBundles pid=3219589 registered=false service=WorkloadAPI subsystem_name=endpoints
```

## Risks and Mitigations

Low to moderate. Although this attempts to fix a bug, the original changes introduced the bug in the first place. I wasn't aware of the dependency spire had on this particular service account through its own configuration. Presumably, though, this doesn't introduce too much risk, since we're adding a service account that Spire expects to exist.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

