### PR TITLE
CASMPET-6937: Update the spire-agent default log level to WARN

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.7.2
+version: 1.7.3
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/values.yaml
+++ b/charts/cray-spire/values.yaml
@@ -121,7 +121,7 @@ tls:
   issuer: cert-manager-issuer-common
 
 agent:
-  logLevel: INFO
+  logLevel: WARN
   wlSocket: /run/cray-spire/sockets
 
   init:


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMPET-6937](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6937)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This changes the log level on spire-agent to WARN. This was chosen because of the amount of logs that the spire-agent gives can cause slowdowns on larger systems. On all internal systems the log messages for info are not needed and provide no helpful data. 

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
           Tested on tyr by changing the loglevel on the config file and restarting the service to ensure it started up.
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
There is no risk as this can be changed on the fly for systems if we need more logging for some reason, however it has never been useful logging to begin with.