### PR TITLE
CASMTRIAGE-8192: Update TTLs for ckdump_helper workload

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.7.5
+version: 1.7.6
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/server/workloads.yaml
+++ b/charts/cray-spire/templates/server/workloads.yaml
@@ -268,6 +268,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/ckdump_helper
+        jwtSVIDTTL: 864000
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/ckdump
         selectors:
           - type: unix
@@ -365,6 +366,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/ckdump_helper
+        jwtSVIDTTL: 864000
       - spiffeID: spiffe://{{ .Values.trustDomain }}/compute/XNAME/workload/ckdump
         selectors:
           - type: unix
@@ -522,6 +524,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/usr/bin/ckdump_helper
+        jwtSVIDTTL: 864000
       - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/ckdump
         selectors:
           - type: unix
@@ -611,6 +614,7 @@ data:
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/ckdump_helper
+        jwtSVIDTTL: 864000
       - spiffeID: spiffe://{{ .Values.trustDomain }}/uan/XNAME/workload/ckdump
         selectors:
           - type: unix


### PR DESCRIPTION
## Summary and Scope

There is a bug where when xname validation is enabled some workloads that need extra long TTLs are changed to have standard TTL. This is incorrect and needed to be addressed.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8192](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8192)

## Testing


### Tested on:

  * lemondrop

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

No risks this is correcting xname validation workloads to what they are in non xname validation workloads.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

