### PR TITLE
CASMPET-7531: Update request-ncn-join daemonset to respect TPM enablement

### DIFF
--- a/charts/cray-spire/Chart.yaml
+++ b/charts/cray-spire/Chart.yaml
@@ -23,7 +23,7 @@
 ---
 apiVersion: v2
 name: cray-spire
-version: 1.7.6
+version: 1.7.7
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:

--- a/charts/cray-spire/templates/ncn/deployment.yaml
+++ b/charts/cray-spire/templates/ncn/deployment.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -71,7 +71,7 @@ spec:
           args:
             - '-x'
             - '-c'
-            - 'count=0; while [ $count -lt 6 ]; do if ! curl --connect-timeout 15 -k -X POST -d type=ncn\&xname=$({{ template "getXname" . }}) "$URL" > /tmp/token; then sleep 5; count=$((count + 1)); else break; fi; done; if [ $count -eq 6 ]; then exit 1; fi; if ! grep -qiE "error|invalid" /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}"; else exit 2;fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while ! [ -e /bundle/bundle.crt ]; do sleep 10; done; cat /bundle/bundle.crt > /token/bundle.crt'
+            - 'if [ -f /token/tpm.enabled ]; then exit 0; fi; count=0; while [ $count -lt 6 ]; do if ! curl --connect-timeout 15 -k -X POST -d type=ncn\&xname=$({{ template "getXname" . }}) "$URL" > /tmp/token; then sleep 5; count=$((count + 1)); else break; fi; done; if [ $count -eq 6 ]; then exit 1; fi; if ! grep -qiE "error|invalid" /tmp/token; then echo "join_token=$(cat /tmp/token | cut -d\" -f4)" > "/token/{{ .Values.ncn.filename }}"; else exit 2;fi; cat /config/spire-agent.conf > /token/spire-agent.conf ; while ! [ -e /bundle/bundle.crt ]; do sleep 10; done; cat /bundle/bundle.crt > /token/bundle.crt'
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
## Summary and Scope

This fixes a bug where if the ncns have been converted to use TPM for node attestation and then the request-join-ncn pods are restarted it wipes away the new spire config. This also makes it so the tpm enabled nodes do not even get a token to improve security for TPM enabled nodes.

## Issues and Related PRs

* Resolves [CASMPET-7531](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7531)

## Testing

### Tested on:

  * mug

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

This takes away risk of generating a join token for each node while TPM node attestation is enabled. There is a risk that a node does not join spire with TPM but the enabled flag is set, which can be mitagated by manually unsetting the file and re-running the join process

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

