### PR TITLE
CASMPET-7525 update spire and cray-spire to use postgresql 2.0.0 for CSM 1.7

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -23,12 +23,12 @@
 #
 apiVersion: v2
 name: spire
-version: 2.16.0
+version: 2.15.7
 description: A Helm chart for spire
 home: https://github.com/Cray-HPE/cray-spire
 dependencies:
   - name: cray-postgresql
-    version: ~2.0.0
+    version: ~1.0.3
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
   - name: kburns-hpe
@@ -51,9 +51,9 @@ annotations:
     - name: nginx
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/nginx:1.18.0-alpine
     - name: pause
-      image: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
+      image: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
     - name: postgres
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:15-alpine
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
     - name: spire-server
       image: artifactory.algol60.net/csm-docker/stable/gcr.io/spiffe-io/spire-server:0.12.2
     - name: spire-agent

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -187,7 +187,7 @@ ncn:
     tag: 7.80.0
   pause:
     repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause
-    tag: "3.10"
+    tag: 3.7
 
 kubectl:
   image:


### PR DESCRIPTION
## Summary and Scope

Updating Postgres Version used by cray-spire

## Issues and Related PRs

* Resolves [CASMPET-7525](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7525)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Small risk changing postgres versions if there is a bug in the newer version, but should limit risk due to a new version

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x]  CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

